### PR TITLE
Save both zarr and zipped zarr

### DIFF
--- a/scratch.py
+++ b/scratch.py
@@ -1,0 +1,6 @@
+import dask.bag
+
+if __name__ == "__main__":
+    bag = dask.bag.from_sequence(range(10))
+    output = bag.map(lambda x: (x+1, x-1)).flatten().compute()
+    print(output)

--- a/scratch.py
+++ b/scratch.py
@@ -1,6 +1,0 @@
-import dask.bag
-
-if __name__ == "__main__":
-    bag = dask.bag.from_sequence(range(10))
-    output = bag.map(lambda x: (x+1, x-1)).flatten().compute()
-    print(output)

--- a/src/nwp_consumer/cmd/main.py
+++ b/src/nwp_consumer/cmd/main.py
@@ -1,8 +1,8 @@
 """nwp-consumer.
 
 Usage:
-  nwp-consumer download --from <startDate> --to <endDate> [options]
-  nwp-consumer convert --from <startDate> --to <endDate> [options]
+  nwp-consumer download [options]
+  nwp-consumer convert [options]
   nwp-consumer consume [options]
   nwp-consumer check
   nwp-consumer (-h | --help)

--- a/src/nwp_consumer/cmd/main.py
+++ b/src/nwp_consumer/cmd/main.py
@@ -28,6 +28,7 @@ Options:
 
 import datetime as dt
 import importlib.metadata
+import shutil
 
 import structlog
 from docopt import docopt
@@ -156,7 +157,12 @@ def main():
         log.error("nwp-consumer error", error=str(e))
         raise e
     finally:
-        _ = [p.unlink(missing_ok=True) for p in TMP_DIR.glob("*")]
+        leftoverTempPaths = list(TMP_DIR.glob("*"))
+        for p in leftoverTempPaths:
+            if p.exists() and p.is_dir():
+                shutil.rmtree(p)
+            if p.is_file():
+                p.unlink(missing_ok=True)
         elapsedTime = dt.datetime.now() - programStartTime
         log.info(
             "nwp-consumer finished",

--- a/src/nwp_consumer/internal/outputs/localfs/client.py
+++ b/src/nwp_consumer/internal/outputs/localfs/client.py
@@ -24,7 +24,14 @@ class LocalFSClient(internal.StorageInterface):
         shutil.move(src=src, dst=dst)
         # Do delete temp file here to avoid local duplication of file.
         src.unlink(missing_ok=True)
-        return os.stat(dst).st_size
+        nbytes = os.stat(dst).st_size
+        log.debug(
+            event="stored file in s3",
+            src=src.as_posix(),
+            dst=dst.as_posix(),
+            nbytes=nbytes
+        )
+        return nbytes
 
     def listInitTimes(self, *, prefix: pathlib.Path) -> list[dt.datetime]:
         # List all the YYYY/MM/DD/INITTIME folders in the given directory

--- a/src/nwp_consumer/internal/outputs/s3/client.py
+++ b/src/nwp_consumer/internal/outputs/s3/client.py
@@ -38,10 +38,22 @@ class S3Client(internal.StorageInterface):
         return self.__fs.exists((self.__bucket / dst).as_posix())
 
     def store(self, *, src: pathlib.Path, dst: pathlib.Path) -> int:
+        log.debug(
+            event="storing file in s3",
+            src=src.as_posix(),
+            dst=(self.__bucket / dst).as_posix(),
+        )
         self.__fs.put(lpath=src.as_posix(), rpath=(self.__bucket / dst).as_posix(), recursive=True)
         # Don't delete temp file as user may want to do further processing locally.
         # All temp files are deleted at the end of the program.
-        return self.__fs.du((self.__bucket / dst).as_posix())
+        nbytes = self.__fs.du((self.__bucket / dst).as_posix())
+        log.debug(
+            event="stored file in s3",
+            src=src.as_posix(),
+            dst=(self.__bucket / dst).as_posix(),
+            nbytes=nbytes
+        )
+        return nbytes
 
     def listInitTimes(self, *, prefix: pathlib.Path) -> list[dt.datetime]:
         """List all initTimes in the raw directory."""

--- a/src/nwp_consumer/internal/service/service.py
+++ b/src/nwp_consumer/internal/service/service.py
@@ -305,7 +305,7 @@ def _saveAsTempRegularZarr(ds: xr.Dataset) -> list[pathlib.Path]:
     initTime = dt.datetime.utcfromtimestamp(int(ds.coords["init_time"].values[0]) / 1e9)
     tempZarrPath = internal.TMP_DIR / (initTime.strftime(internal.ZARR_FMTSTR) + ".zarr")
     if tempZarrPath.exists() and tempZarrPath.is_dir():
-        tempZarrPath.rmdir()
+        shutil.rmtree(tempZarrPath.as_posix())
     ds.to_zarr(
         store=tempZarrPath.as_posix(),
         encoding={

--- a/src/nwp_consumer/internal/service/service.py
+++ b/src/nwp_consumer/internal/service/service.py
@@ -78,9 +78,9 @@ class NWPConsumerService:
             .map(lambda fi: self.fetcher.downloadToTemp(fi=fi)) \
             .filter(lambda infoPathTuple: infoPathTuple[1] != pathlib.Path()) \
             .map(lambda infoPathTuple: self.storer.store(
-            src=infoPathTuple[1],
-            dst=self.rawdir / infoPathTuple[0].it().strftime(internal.IT_FOLDER_FMTSTR) / (infoPathTuple[0].filename())
-        )) \
+                src=infoPathTuple[1],
+                dst=self.rawdir / infoPathTuple[0].it().strftime(internal.IT_FOLDER_FMTSTR) / (infoPathTuple[0].filename())
+            )) \
             .sum() \
             .compute()
 

--- a/src/nwp_consumer/internal/service/service.py
+++ b/src/nwp_consumer/internal/service/service.py
@@ -283,7 +283,7 @@ class NWPConsumerService:
         return 0
 
 
-def _saveAsTempZipZarr(ds: xr.Dataset) -> list[pathlib.Path]:
+def _saveAsTempZipZarr(ds: xr.Dataset) -> pathlib.Path:
     # Save the dataset to a temp zarr file
     initTime = dt.datetime.utcfromtimestamp(int(ds.coords["init_time"].values[0]) / 1e9)
     tempZarrPath = internal.TMP_DIR / (initTime.strftime(internal.ZARR_FMTSTR) + ".zarr.zip")
@@ -302,7 +302,7 @@ def _saveAsTempZipZarr(ds: xr.Dataset) -> list[pathlib.Path]:
     return tempZarrPath
 
 
-def _saveAsTempRegularZarr(ds: xr.Dataset) -> list[pathlib.Path]:
+def _saveAsTempRegularZarr(ds: xr.Dataset) -> pathlib.Path:
     # Save the dataset to a temp zarr file
     initTime = dt.datetime.utcfromtimestamp(int(ds.coords["init_time"].values[0]) / 1e9)
     tempZarrPath = internal.TMP_DIR / (initTime.strftime(internal.ZARR_FMTSTR) + ".zarr")

--- a/src/nwp_consumer/internal/service/test_service.py
+++ b/src/nwp_consumer/internal/service/test_service.py
@@ -123,8 +123,8 @@ class TestNWPConsumerService(unittest.TestCase):
 
     def test_createLatestZarr(self):
 
-        n = self.service.CreateLatestZarr()
-        self.assertEqual(len("latest.zarr.zip"), n)
+        n1 = self.service.CreateLatestZarr()
+        self.assertEqual(len("latest.zarr.zip"), n1)
 
 
 # ------------ Static Methods ----------- #

--- a/src/nwp_consumer/internal/service/test_service.py
+++ b/src/nwp_consumer/internal/service/test_service.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import pathlib
+import shutil
 import unittest
 
 import numpy as np
@@ -26,7 +27,10 @@ class DummyStorer(internal.StorageInterface):
         return False
 
     def store(self, *, src: pathlib.Path, dst: pathlib.Path) -> int:
-        src.unlink(missing_ok=True)
+        if src.is_dir():
+            shutil.rmtree(src.as_posix(), ignore_errors=True)
+        else:
+            src.unlink(missing_ok=True)
         return len(dst.name)
 
     def listInitTimes(self, prefix: pathlib.Path) -> list[dt.datetime]:

--- a/src/nwp_consumer/internal/service/test_service.py
+++ b/src/nwp_consumer/internal/service/test_service.py
@@ -4,7 +4,6 @@ import unittest
 
 import numpy as np
 import xarray as xr
-import zarr
 
 from .. import FileInfoModel
 from .. import models as internal


### PR DESCRIPTION
In order to allow backwards compatibility for the current consumer, modify the behavior of the CreateLatest function to save both zipped and regular zarrs.