### PR TITLE
Set AWS credentials as optional env vars, use defaults if not set

### DIFF
--- a/src/nwp_consumer/internal/config/config.py
+++ b/src/nwp_consumer/internal/config/config.py
@@ -49,6 +49,7 @@ class S3Config(_EnvParseMixin):
     """Config for S3."""
 
     AWS_S3_BUCKET: str
-    AWS_ACCESS_KEY: str
-    AWS_ACCESS_SECRET: str
     AWS_REGION: str
+    # Optional, attempts to use default AWS credentials if not set
+    AWS_ACCESS_KEY: str | None = None
+    AWS_ACCESS_SECRET: str | None = None

--- a/src/nwp_consumer/internal/config/config.py
+++ b/src/nwp_consumer/internal/config/config.py
@@ -51,5 +51,5 @@ class S3Config(_EnvParseMixin):
     AWS_S3_BUCKET: str
     AWS_REGION: str
     # Optional, attempts to use default AWS credentials if not set
-    AWS_ACCESS_KEY: str | None = None
-    AWS_ACCESS_SECRET: str | None = None
+    AWS_ACCESS_KEY: str 
+    AWS_ACCESS_SECRET: str

--- a/src/nwp_consumer/internal/config/config.py
+++ b/src/nwp_consumer/internal/config/config.py
@@ -49,7 +49,6 @@ class S3Config(_EnvParseMixin):
     """Config for S3."""
 
     AWS_S3_BUCKET: str
-    AWS_REGION: str
-    # Optional, attempts to use default AWS credentials if not set
-    AWS_ACCESS_KEY: str 
+    AWS_ACCESS_KEY: str
     AWS_ACCESS_SECRET: str
+    AWS_REGION: str

--- a/src/nwp_consumer/internal/outputs/s3/client.py
+++ b/src/nwp_consumer/internal/outputs/s3/client.py
@@ -23,14 +23,26 @@ class S3Client(internal.StorageInterface):
     def __init__(self, key: str, secret: str, bucket: str, region: str,
                  endpointURL: str = None):
         """Create a new S3Client."""
-        self.__fs: s3fs.S3FileSystem = s3fs.S3FileSystem(
-            key=key,
-            secret=secret,
-            client_kwargs={
-                'region_name': region,
-                'endpoint_url': endpointURL,
-            }
-        )
+        if (key != '') and (secret != ''):
+            self.__fs: s3fs.S3FileSystem = s3fs.S3FileSystem(
+                key=key,
+                secret=secret,
+                client_kwargs={
+                    'region_name': region,
+                    'endpoint_url': endpointURL,
+                }
+            )
+        else:
+            # try without passing the key or secret.
+            # It should load the values from default AWS credentials file
+            log.debug(event="Will be loading credentials from default AWS credentials file, "
+                            "as key or secret was not passed")
+            self.__fs: s3fs.S3FileSystem = s3fs.S3FileSystem(
+                client_kwargs={
+                    'region_name': region,
+                    'endpoint_url': endpointURL,
+                }
+            )
 
         self.__bucket = pathlib.Path(bucket)
 


### PR DESCRIPTION
Addresses #20. This works assuming that the s3fs `S3FileSystem` automatically tries to access default connection values from the environment when `key` and `secret` are `None`.