### PR TITLE
Modify order of variables in dataset, scan y backwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ NWP CONSUMER
 <br>
 <br>
 Microservice for consuming NWP data.
-</h2>The build configuration for the service
+</h2>
 
 <div align="center">
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ NWP CONSUMER
 <br>
 <br>
 Microservice for consuming NWP data.
-</h2>
+</h2>The build configuration for the service
 
 <div align="center">
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,27 +55,34 @@ enabled = true
 # --- LINTING AND TYPING CONFIGURATION --- #
 
 # MyPy configuration
+# * See https://mypy.readthedocs.io/en/stable/index.html
 [tool.mypy]
 python_version = "3.10"
 plugins = [
     'numpy.typing.mypy_plugin'
 ]
 
-# ruff configuration
+# Ruff configuration
+# * See https://beta.ruff.rs/docs/
 [tool.ruff]
 select = [
-    "E", # pycodestyle
-    "W", # newline at end of files
-    "F", # pyflakes
-    "B", # flake8-bugbear
-    "I", # isosort
-    "D", # pydocstyle
-    "S", # flake8-bandit
-    "T20", # flake8-print
+    "F",   # pyflakes
+    "E",   # pycodestyle
+    "W",   # whitespace and newlines
+    "I",   # isort
+    "UP",  # modernize
+    "ANN", # flake8 type annotations
+    "S",   # flake8 bandit
+    "B",   # flake8 bugbear
+    "C4",  # flake8 comprehensions
+    "T20", # flake8 print
+    "SIM", # flake8 simplify
+    "ARG", # flake8 unused arguments
+    "D",   # pydocstyle
 ]
 line-length = 100
-ignore = ["D203", "D213"]
+ignore = ["D203", "D213", "ANN101"]
 exclude = ["__init__.py"]
 
 [tool.ruff.per-file-ignores]
-"test*" = ["S101", "D102", "D103", "PT004", "PT012"]
+"test*" = ["D", "ANN"]

--- a/src/nwp_consumer/cmd/main.py
+++ b/src/nwp_consumer/cmd/main.py
@@ -26,6 +26,7 @@ Options:
   --verbose           Enable verbose logging [default: False].
 """
 
+import contextlib
 import datetime as dt
 import importlib.metadata
 import shutil
@@ -33,16 +34,13 @@ import shutil
 import structlog
 from docopt import docopt
 
-from nwp_consumer.internal import config, inputs, outputs, TMP_DIR
+from nwp_consumer.internal import TMP_DIR, config, inputs, outputs
 from nwp_consumer.internal.service import NWPConsumerService
 
 __version__ = "local"
 
-try:
-    __version__ = importlib.metadata.version("nwp-consumer")
-except importlib.metadata.PackageNotFoundError:
-    # package is not installed
-    pass
+with contextlib.suppress(importlib.metadata.PackageNotFoundError):
+    __version__ = importlib.metadata.version("package-name")
 
 log = structlog.getLogger()
 
@@ -148,7 +146,7 @@ def run():
         service.CreateLatestZarr()
 
 
-def main():
+def main() -> None:
     """Entry point for the nwp-consumer CLI."""
     programStartTime = dt.datetime.now()
     try:

--- a/src/nwp_consumer/internal/config/config.py
+++ b/src/nwp_consumer/internal/config/config.py
@@ -1,8 +1,8 @@
 """Config struct for application running."""
 
 import os
-from distutils.util import strtobool
 from typing import get_type_hints
+
 import structlog
 
 log = structlog.getLogger()
@@ -11,7 +11,7 @@ log = structlog.getLogger()
 class _EnvParseMixin:
     """Mixin to parse environment variables into class fields."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         for field, _ in get_type_hints(self).items():
             # Skip item if not upper case
             if not field.isupper():
@@ -21,7 +21,7 @@ class _EnvParseMixin:
             default_value = getattr(self, field, None)
             if default_value is None and os.environ.get(field) is None:
                 log.warn(
-                    event=f"environment variable not set",
+                    event="environment variable not set",
                     variable=field,
                 )
                 default_value = ""

--- a/src/nwp_consumer/internal/inputs/ceda/_models.py
+++ b/src/nwp_consumer/internal/inputs/ceda/_models.py
@@ -1,6 +1,5 @@
 import datetime as dt
-import pathlib
-from typing import ClassVar, Type
+from typing import ClassVar
 
 from marshmallow import EXCLUDE, Schema, fields
 from marshmallow_dataclass import dataclass
@@ -17,7 +16,7 @@ class CEDAFileInfo(internal.FileInfoModel):
 
     name: str
 
-    Schema: ClassVar[Type[Schema]] = Schema  # To prevent confusing type checkers
+    Schema: ClassVar[type[Schema]] = Schema  # To prevent confusing type checkers
 
     def it(self) -> dt.datetime:
         """Return the init time of the file.
@@ -44,4 +43,4 @@ class CEDAResponse:
     path: str
     items: list[CEDAFileInfo] = fields.List(fields.Nested(CEDAFileInfo.Schema()))
 
-    Schema: ClassVar[Type[Schema]] = Schema  # To prevent confusing type checkers
+    Schema: ClassVar[type[Schema]] = Schema  # To prevent confusing type checkers

--- a/src/nwp_consumer/internal/inputs/ceda/client.py
+++ b/src/nwp_consumer/internal/inputs/ceda/client.py
@@ -56,7 +56,7 @@ class CEDAClient(internal.FetcherInterface):
     # FTP url for CEDA data
     __ftpBase: str
 
-    def __init__(self, ftpUsername: str, ftpPassword: str):
+    def __init__(self, ftpUsername: str, ftpPassword: str) -> None:
         self.__username: str = urllib.parse.quote(ftpUsername)
         self.__password: str = urllib.parse.quote(ftpPassword)
         self.__ftpBase: str = f'ftp://{self.__username}:{self.__password}@ftp.ceda.ac.uk'
@@ -71,7 +71,7 @@ class CEDAClient(internal.FetcherInterface):
             return fi, pathlib.Path()
 
         log.debug(
-            event=f"requesting download of file",
+            event="requesting download of file",
             file=fi.filename(),
             path=fi.filepath()
         )
@@ -95,7 +95,7 @@ class CEDAClient(internal.FetcherInterface):
                 f.flush()
 
         log.debug(
-            event=f"fetched all data from file",
+            event="fetched all data from file",
             filename=fi.filename(),
             url=fi.filepath(),
             filepath=tfp.as_posix(),
@@ -116,7 +116,7 @@ class CEDAClient(internal.FetcherInterface):
         if response.status_code == 404:
             # No data available for this init time. Fail soft
             log.warn(
-                event=f"no data available for init time",
+                event="no data available for init time",
                 init_time=f"{it:%Y/%m/%d %H:%M}",
                 url=response.url
             )
@@ -160,7 +160,7 @@ class CEDAClient(internal.FetcherInterface):
         )
 
         # Check the file has the right name
-        if not any([setname in p.name.lower() for setname in ["wholesale1.grib", "wholesale2.grib"]]):
+        if not any(setname in p.name.lower() for setname in ["wholesale1.grib", "wholesale2.grib"]):
             log.debug(
                 event="skipping file as it does not match expected name",
                 filepath=p.as_posix()
@@ -258,7 +258,7 @@ class CEDAClient(internal.FetcherInterface):
             .expand_dims("init_time") \
             .to_array(dim="variable", name="UKV") \
             .to_dataset() \
-            .transpose("init_time", "step", "variable", "y", "x") \
+            .transpose("variable", "init_time", "step", "y", "x") \
             .sortby("step") \
             .sortby("variable") \
             .chunk({
@@ -284,7 +284,7 @@ def _isWantedFile(*, fi: CEDAFileInfo, dit: dt.datetime) -> bool:
             fi.it().time() != dit.time():
         return False
     # False if item doesn't correspond to Wholesale1 or Wholesale2 files
-    if not any([setname in fi.filename() for setname in ["Wholesale1.grib", "Wholesale2.grib"]]):
+    if not any(setname in fi.filename() for setname in ["Wholesale1.grib", "Wholesale2.grib"]):
         return False
 
     return True

--- a/src/nwp_consumer/internal/inputs/ceda/test_client.py
+++ b/src/nwp_consumer/internal/inputs/ceda/test_client.py
@@ -39,11 +39,17 @@ class TestClient_ConvertRawFileToDataset(unittest.TestCase):
         out = testClient.mapTemp(p=wholesalePath)
 
         # Ensure the dimensions have the right sizes
-        self.assertDictEqual({"init_time": 1, "variable": 6, "step": 4, "y": 704, "x": 548}, dict(out.dims.items()))
+        self.assertDictEqual(
+            {"init_time": 1, "variable": 6, "step": 4, "y": 704, "x": 548},
+            dict(out.dims.items())
+        )
         # Ensure the dimensions of the variables are in the correct order
-        self.assertEqual(("init_time", "step", "variable", "y", "x"), out["UKV"].dims)
+        self.assertEqual(("variable", "init_time", "step", "y", "x"), out["UKV"].dims)
         # Ensure the correct variables are in the variable dimension
-        self.assertListEqual(['prate', 'r', 'si10', 't', 'vis', 'wdir10'], sorted(list(out.coords["variable"].values)))
+        self.assertListEqual(
+            ['prate', 'r', 'si10', 't', 'vis', 'wdir10'],
+            sorted(out.coords["variable"].values)
+        )
 
     def test_convertsWholesale2FileCorrectly(self):
         wholesalePath: pathlib.Path = pathlib.Path(__file__).parent / "test_wholesale2.grib"
@@ -51,18 +57,26 @@ class TestClient_ConvertRawFileToDataset(unittest.TestCase):
         out = testClient.mapTemp(p=wholesalePath)
 
         # Ensure the dimensions have the right sizes
-        self.assertDictEqual({"init_time": 1, "variable": 6, "step": 4, "y": 704, "x": 548}, dict(out.dims.items()))
+        self.assertDictEqual(
+            {"init_time": 1, "variable": 6, "step": 4, "y": 704, "x": 548},
+            dict(out.dims.items())
+        )
         # Ensure the dimensions of the variables are in the correct order
-        self.assertEqual(("init_time", "step", "variable", "y", "x"), out["UKV"].dims)
+        self.assertEqual(("variable", "init_time", "step", "y", "x"), out["UKV"].dims)
         # Ensure the correct variables are in the variable dimension
-        self.assertListEqual(['dlwrf', 'dswrf', 'hcc', 'lcc', 'mcc', 'sde'], sorted(list(out.coords["variable"].values)))
+        self.assertListEqual(
+            ['dlwrf', 'dswrf', 'hcc', 'lcc', 'mcc', 'sde'],
+            sorted(out.coords["variable"].values)
+        )
 
 # --------- Static methods --------- #
 
 class TestIsWantedFile(unittest.TestCase):
 
     def test_correctlyFiltersCEDAFileInfos(self):
-        initTime: dt.datetime = dt.datetime(year=2021, month=1, day=1, hour=0, minute=0, tzinfo=None)
+        initTime: dt.datetime = dt.datetime(
+            year=2021, month=1, day=1, hour=0, minute=0, tzinfo=None
+        )
 
         wantedFileInfos: list[CEDAFileInfo] = [
             CEDAFileInfo(name="202101010000_u1096_ng_umqv_Wholesale1.grib"),
@@ -82,9 +96,9 @@ class TestIsWantedFile(unittest.TestCase):
         ]
 
         self.assertTrue(
-            all([_isWantedFile(fi=fo, dit=initTime) for fo in wantedFileInfos]))
+            all(_isWantedFile(fi=fo, dit=initTime) for fo in wantedFileInfos))
         self.assertFalse(
-            all([_isWantedFile(fi=fo, dit=initTime) for fo in unwantedFileInfos]))
+            all(_isWantedFile(fi=fo, dit=initTime) for fo in unwantedFileInfos))
 
 
 class TestReshapeTo2DGrid(unittest.TestCase):

--- a/src/nwp_consumer/internal/inputs/metoffice/_models.py
+++ b/src/nwp_consumer/internal/inputs/metoffice/_models.py
@@ -1,6 +1,5 @@
 import datetime as dt
-import pathlib
-from typing import ClassVar, Type
+from typing import ClassVar
 
 from marshmallow import EXCLUDE, Schema, fields
 from marshmallow_dataclass import dataclass
@@ -17,7 +16,7 @@ class MetOfficeFileInfo(internal.FileInfoModel):
     fileId: str
     runDateTime: dt.datetime
 
-    Schema: ClassVar[Type[Schema]] = Schema  # To prevent confusing type checkers
+    Schema: ClassVar[type[Schema]] = Schema  # To prevent confusing type checkers
 
     def it(self) -> dt.datetime:
         return self.runDateTime.replace(tzinfo=None)
@@ -39,7 +38,7 @@ class MetOfficeOrderDetails:
 
     files: list[MetOfficeFileInfo] = fields.List(fields.Nested(MetOfficeFileInfo.Schema()))
 
-    Schema: ClassVar[Type[Schema]] = Schema  # To prevent confusing type checkers
+    Schema: ClassVar[type[Schema]] = Schema  # To prevent confusing type checkers
 
 
 @dataclass
@@ -47,4 +46,4 @@ class MetOfficeResponse:
 
     orderDetails: MetOfficeOrderDetails
 
-    Schema: ClassVar[Type[Schema]] = Schema  # To prevent confusing type checkers
+    Schema: ClassVar[type[Schema]] = Schema  # To prevent confusing type checkers

--- a/src/nwp_consumer/internal/inputs/metoffice/test_client.py
+++ b/src/nwp_consumer/internal/inputs/metoffice/test_client.py
@@ -37,11 +37,14 @@ class TestClient_ConvertRawFileToDataset(unittest.TestCase):
         out = testClient.mapTemp(p=testFilePath)
 
         # Ensure the dimensions have the right sizes
-        self.assertDictEqual({"init_time": 1, "variable": 1, "step": 13, "y": 639, "x": 455}, dict(out.dims.items()))
+        self.assertDictEqual(
+            {"init_time": 1, "variable": 1, "step": 13, "y": 639, "x": 455},
+            dict(out.dims.items())
+        )
         # Ensure the dimensions of the variables are in the correct order
-        self.assertEqual(("init_time", "step", "variable", "y", "x"), out["UKV"].dims)
+        self.assertEqual(("variable", "init_time", "step", "y", "x"), out["UKV"].dims)
         # Ensure the correct variables are in the variable dimension
-        self.assertListEqual(['dswrf'], sorted(list(out.coords["variable"].values)))
+        self.assertListEqual(['dswrf'], sorted(out.coords["variable"].values))
 
     def test_renamesVariables(self):
         testFilePath: pathlib.Path = pathlib.Path(__file__).parent / "test_wrongnameparam.grib"
@@ -49,11 +52,14 @@ class TestClient_ConvertRawFileToDataset(unittest.TestCase):
         out = testClient.mapTemp(p=testFilePath)
 
         # Ensure the dimensions have the right sizes
-        self.assertDictEqual({"init_time": 1, "variable": 1, "step": 13, "y": 639, "x": 455}, dict(out.dims.items()))
+        self.assertDictEqual(
+            {"init_time": 1, "variable": 1, "step": 13, "y": 639, "x": 455},
+            dict(out.dims.items())
+        )
         # Ensure the dimensions of the variables are in the correct order
-        self.assertEqual(("init_time", "step", "variable", "y", "x"), out["UKV"].dims)
+        self.assertEqual(out["UKV"].dims, ("variable", "init_time", "step", "y", "x"))
         # Ensure the correct variables are in the variable dimension
-        self.assertListEqual(['prate'], sorted(list(out.coords["variable"].values)))
+        self.assertListEqual(['prate'], sorted(out.coords["variable"].values))
 
     def test_handlesUnknownsInMetOfficeData(self):
         testFilePath: pathlib.Path = pathlib.Path(__file__).parent / "test_unknownparam1.grib"
@@ -61,32 +67,42 @@ class TestClient_ConvertRawFileToDataset(unittest.TestCase):
         out = testClient.mapTemp(p=testFilePath)
 
         # Ensure the dimensions have the right sizes
-        self.assertDictEqual({"init_time": 1, "variable": 1, "step": 43, "y": 639, "x": 455}, dict(out.dims.items()))
+        self.assertDictEqual(
+            {"init_time": 1, "variable": 1, "step": 43, "y": 639, "x": 455},
+            dict(out.dims.items())
+        )
         # Ensure the dimensions of the variables are in the correct order
-        self.assertEqual(("init_time", "step", "variable", "y", "x"), out["UKV"].dims)
+        self.assertEqual(out["UKV"].dims, ("variable", "init_time", "step", "y", "x"))
         # Ensure the correct variables are in the variable dimension
-        self.assertListEqual(['si10'], sorted(list(out.coords["variable"].values)))
-        self.assertNotEqual(['unknown'], sorted(list(out.coords["variable"].values)))
+        self.assertListEqual(['si10'], sorted(out.coords["variable"].values))
+        self.assertNotEqual(['unknown'], sorted(out.coords["variable"].values))
 
         testFilePath: pathlib.Path = pathlib.Path(__file__).parent / "test_unknownparam2.grib"
 
         out = testClient.mapTemp(p=testFilePath)
 
         # Ensure the dimensions have the right sizes
-        self.assertDictEqual({"init_time": 1, "variable": 1, "step": 10, "y": 639, "x": 455}, dict(out.dims.items()))
+        self.assertDictEqual(
+            {"init_time": 1, "variable": 1, "step": 10, "y": 639, "x": 455},
+            dict(out.dims.items())
+        )
         # Ensure the dimensions of the variables are in the correct order
-        self.assertEqual(("init_time", "step", "variable", "y", "x"), out["UKV"].dims)
+        self.assertEqual(("variable", "init_time", "step", "y", "x"), out["UKV"].dims)
         # Ensure the correct variables are in the variable dimension
-        self.assertListEqual(['wdir10'], sorted(list(out.coords["variable"].values)))
-        self.assertNotEqual(['unknown'], sorted(list(out.coords["variable"].values)))
+        self.assertListEqual(['wdir10'], sorted(out.coords["variable"].values))
+        self.assertNotEqual(['unknown'], sorted(out.coords["variable"].values))
+
 
 # --------- Static methods --------- #
+
 
 class Test_IsWantedFile(unittest.TestCase):
     """Tests for the _isWantedFile method."""
 
     def test_correctlyFiltersMetOfficeFileInfos(self):
-        initTime: dt.datetime = dt.datetime(year=2023, month=3, day=24, hour=0, minute=0, tzinfo=None)
+        initTime: dt.datetime = dt.datetime(
+            year=2023, month=3, day=24, hour=0, minute=0, tzinfo=None
+        )
 
         wantedFileInfos: list[MetOfficeFileInfo] = [
             MetOfficeFileInfo(
@@ -110,6 +126,6 @@ class Test_IsWantedFile(unittest.TestCase):
             ),
         ]
 
-        self.assertTrue(all([_isWantedFile(fi=fo, dit=initTime) for fo in wantedFileInfos]))
-        self.assertFalse(all([_isWantedFile(fi=fo, dit=initTime) for fo in unwantedFileInfos]))
+        self.assertTrue(all(_isWantedFile(fi=fo, dit=initTime) for fo in wantedFileInfos))
+        self.assertFalse(all(_isWantedFile(fi=fo, dit=initTime) for fo in unwantedFileInfos))
 

--- a/src/nwp_consumer/internal/outputs/localfs/client.py
+++ b/src/nwp_consumer/internal/outputs/localfs/client.py
@@ -49,14 +49,14 @@ class LocalFSClient(internal.StorageInterface):
                 initTimes.add(ddt)
             except ValueError:
                 log.debug(
-                    event=f"ignoring invalid folder name",
+                    event="ignoring invalid folder name",
                     name=dir.as_posix(),
                     within=prefix.as_posix()
                 )
 
         if len(initTimes) == 0:
             log.debug(
-                event=f"no init times found in raw directory",
+                event="no init times found in raw directory",
                 within=prefix.as_posix()
             )
             return []

--- a/src/nwp_consumer/internal/outputs/s3/client.py
+++ b/src/nwp_consumer/internal/outputs/s3/client.py
@@ -21,7 +21,7 @@ class S3Client(internal.StorageInterface):
     __s3: botocore.client
 
     def __init__(self, key: str, secret: str, bucket: str, region: str,
-                 endpointURL: str = None):
+                 endpointURL: str = None) -> None:
         """Create a new S3Client."""
         if (key != '') and (secret != ''):
             self.__fs: s3fs.S3FileSystem = s3fs.S3FileSystem(
@@ -87,7 +87,7 @@ class S3Client(internal.StorageInterface):
                     ).replace(tzinfo=None)
                     initTimes.add(ddt)
                 except ValueError:
-                    log.debug(f"ignoring invalid folder name", name=dir.as_posix(), within=prefix.as_posix())
+                    log.debug("ignoring invalid folder name", name=dir.as_posix(), within=prefix.as_posix())
 
         sortedInitTimes = sorted(initTimes)
         log.debug(

--- a/src/nwp_consumer/internal/outputs/s3/client.py
+++ b/src/nwp_consumer/internal/outputs/s3/client.py
@@ -23,26 +23,22 @@ class S3Client(internal.StorageInterface):
     def __init__(self, key: str, secret: str, bucket: str, region: str,
                  endpointURL: str = None) -> None:
         """Create a new S3Client."""
-        if (key != '') and (secret != ''):
-            self.__fs: s3fs.S3FileSystem = s3fs.S3FileSystem(
-                key=key,
-                secret=secret,
-                client_kwargs={
-                    'region_name': region,
-                    'endpoint_url': endpointURL,
-                }
+
+        (key, secret) = (None, None) if (key, secret) == ("", "") else (key, secret)
+        if key is None and secret is None:
+            log.info(
+                event="attempting AWS connection using default credentials",
             )
-        else:
-            # try without passing the key or secret.
-            # It should load the values from default AWS credentials file
-            log.debug(event="Will be loading credentials from default AWS credentials file, "
-                            "as key or secret was not passed")
-            self.__fs: s3fs.S3FileSystem = s3fs.S3FileSystem(
-                client_kwargs={
-                    'region_name': region,
-                    'endpoint_url': endpointURL,
-                }
-            )
+
+        # S3FileSystem will attempt connection via default credentials if key and secret are None
+        self.__fs: s3fs.S3FileSystem = s3fs.S3FileSystem(
+            key=key,
+            secret=secret,
+            client_kwargs={
+                'region_name': region,
+                'endpoint_url': endpointURL,
+            }
+        )
 
         self.__bucket = pathlib.Path(bucket)
 

--- a/src/nwp_consumer/internal/outputs/s3/test_client.py
+++ b/src/nwp_consumer/internal/outputs/s3/test_client.py
@@ -58,7 +58,6 @@ class TestS3Client(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         # Delete all objects in bucket
-        print("Tearing down bucket")
         response = cls.testS3.list_objects_v2(
             Bucket=BUCKET,
         )
@@ -210,7 +209,7 @@ class TestS3Client(unittest.TestCase):
 
         # Call the copyITFolderToTemp method again
         paths = self.client.copyITFolderToTemp(prefix=RAW, it=initTime2)
-        assert len(paths) == 3
+        self.assertEqual(len(paths), 3)
 
         # Delete the files in S3
         for f in files2:

--- a/src/nwp_consumer/internal/service/test_service.py
+++ b/src/nwp_consumer/internal/service/test_service.py
@@ -76,7 +76,10 @@ class DummyFetcher(internal.FetcherInterface):
         initTime = dt.datetime.strptime(p.parent.as_posix(), "%Y%m%d%H%M")
         return xr.Dataset(
             data_vars={
-                'UKV': (('init_time', 'variable', 'step', 'x', 'y'), np.random.rand(1, 1, 12, 100, 100)),
+                'UKV': (
+                    ('init_time', 'variable', 'step', 'x', 'y'),
+                    np.random.rand(1, 1, 12, 100, 100)
+                ),
             },
             coords={
                 'init_time': [initTime],

--- a/src/test_integration/test_inputs_integration.py
+++ b/src/test_integration/test_inputs_integration.py
@@ -12,7 +12,8 @@ from nwp_consumer.internal.inputs.ceda._models import CEDAFileInfo
 from nwp_consumer.internal.inputs.metoffice._models import MetOfficeFileInfo
 
 cedaInitTime: dt.datetime = dt.datetime(year=2022, month=1, day=1, hour=0, minute=0, tzinfo=None)
-metOfficeInitTime: dt.datetime = dt.datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+metOfficeInitTime: dt.datetime = dt.datetime.now() \
+    .replace(hour=0, minute=0, second=0, microsecond=0)
 
 cc = config.CEDAConfig()
 mc = config.MetOfficeConfig()

--- a/src/test_integration/test_service_integration.py
+++ b/src/test_integration/test_service_integration.py
@@ -12,8 +12,7 @@ import unittest
 import numpy as np
 import ocf_blosc2  # noqa: F401
 import xarray as xr
-
-from nwp_consumer.internal import config, inputs, outputs, service, ZARR_FMTSTR
+from nwp_consumer.internal import ZARR_FMTSTR, config, inputs, outputs, service
 
 
 class TestNWPConsumerService_MetOffice(unittest.TestCase):
@@ -52,7 +51,10 @@ class TestNWPConsumerService_MetOffice(unittest.TestCase):
             numVars = len(ds.coords["variable"].values)
 
             # Ensure the dimensions have the right sizes
-            self.assertDictEqual({"init_time": 1, "step": 13, "variable": numVars, "y": 639, "x": 455}, dict(ds.dims.items()))
+            self.assertDictEqual(
+                {"init_time": 1, "step": 13, "variable": numVars, "y": 639, "x": 455},
+                dict(ds.dims.items())
+            )
             # Ensure the dimensions of the variables are in the correct order
             self.assertEqual(("init_time", "step", "variable", "y", "x"), ds["UKV"].dims)
             # Ensure the init time is correct
@@ -97,7 +99,10 @@ class TestNWPConsumerService_CEDA(unittest.TestCase):
             # Enusre the data variables are correct
             self.assertEqual(["UKV"], list(ds.data_vars))
             # Ensure the dimensions have the right sizes
-            self.assertEqual({'init_time': 1, 'step': 37, 'variable': 12, 'y': 704, 'x': 548}, dict(ds.dims.items()))
+            self.assertEqual(
+                {'init_time': 1, 'step': 37, 'variable': 12, 'y': 704, 'x': 548},
+                dict(ds.dims.items())
+            )
             # Ensure the init time is correct
             self.assertEqual(
                 np.datetime64(dt.datetime.strptime(path.with_suffix('').stem, ZARR_FMTSTR)),


### PR DESCRIPTION
National forecaster was failing as it expected y to scan negatively. This resolves that, as well as the wrong shape failure seen in the regular forecaster by reordering the variables.

See #24 