### PR TITLE
Enable pulling all data from Icon via env var

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,8 @@ enabled = true
 # * See https://mypy.readthedocs.io/en/stable/index.html
 [tool.mypy]
 python_version = "3.10"
+warn_return_any = true
+disallow_untyped_defs = true
 plugins = [
     'numpy.typing.mypy_plugin'
 ]

--- a/src/nwp_consumer/internal/config/env.py
+++ b/src/nwp_consumer/internal/config/env.py
@@ -61,6 +61,7 @@ class ICONEnv(EnvParser):
     """Config for ICON API."""
 
     ICON_MODEL: str = "europe"
+    ICON_PARAMETER_GROUP: str = "default"
 
 
 # --- Outputs environment variables --- #

--- a/src/nwp_consumer/internal/inputs/icon/_consts.py
+++ b/src/nwp_consumer/internal/inputs/icon/_consts.py
@@ -1,0 +1,32 @@
+"""Defines all parameters available from icon."""
+
+
+EU_SL_VARS = [
+    "alb_rad", "alhfl_s", "ashfl_s", "asob_s", "asob_t",
+    "aswdifd_s", "aswdifu_s", "aswdir_s", "athb_s",
+    "athb_t", "aumfl_s" "avmfl_s",
+    "cape_con", "cape_ml", "clch", "clcl", "clcm", "clct", "clct_mod", "cldepth",
+    "h_snow", "hbas_con", "htop_con", "htop_dc", "hzerocl",
+    "pmsl", "ps",
+    "qv_2m", "qv_s",
+    "rain_con", "rain_gsp", "relhum_2m", "rho_snow", "runoff_g", "runoff_s",
+    "snow_con", "snow_gsp", "snowlmt", "synmsg_bt_cl_ir10.8",
+    "t_2m", "t_g", "t_snow", "tch", "tcm", "td_2m",
+    "tmax_2m", "tmin_2m", "tot_prec", "tqc", "tqi",
+    "u_10m", "v_10m", "vmax_10m",
+    "w_snow", "w_so", "ww",
+    "z0",
+]
+
+EU_ML_VARS = ["clc", "fi", "omega", "p", "qv", "relhum", "t", "tke", "u", "v", "w"]
+
+GLOBAL_SL_VARS = EU_SL_VARS + [
+    "alb_rad",
+    "c_t_lk",
+    "freshsnw", "fr_ice",
+    "h_ice", "h_ml_lk",
+    "t_ice", "t_s", "tqr", "tqs", "tqv",
+]
+
+GLOBAL_ML_VARS: list[str] = ["fi", "relhum", "t", "u", "v"]
+

--- a/src/nwp_consumer/internal/inputs/icon/_models.py
+++ b/src/nwp_consumer/internal/inputs/icon/_models.py
@@ -5,19 +5,19 @@ from nwp_consumer import internal
 
 
 class IconFileInfo(internal.FileInfoModel):
-    def __init__(self, it: dt.datetime, filename: str, currentURL: str):
+    def __init__(self, it: dt.datetime, filename: str, currentURL: str, step: int) -> "IconFileInfo":
         self._it = it
         # The name of the file when stored by the storer. We decompress from bz2
         # at download time, so we don't want that extension on the filename.
         self._filename = filename.replace(".bz2", "")
         self._url = currentURL
-
+        self.step = step
 
     def filename(self) -> str:
         return self._filename
 
     def filepath(self) -> str:
-        # The filename in the fuly-qualified filepath still has the .bz2 extension
+        # The filename in the fully-qualified filepath still has the .bz2 extension
         # so add it back in
         return self._url + "/" + self._filename + ".bz2"
 

--- a/src/nwp_consumer/internal/inputs/icon/client.py
+++ b/src/nwp_consumer/internal/inputs/icon/client.py
@@ -12,6 +12,7 @@ import xarray as xr
 
 from nwp_consumer import internal
 
+from ._consts import GLOBAL_ML_VARS, GLOBAL_SL_VARS, EU_ML_VARS, EU_SL_VARS
 from ._models import IconFileInfo
 
 log = structlog.getLogger()
@@ -28,32 +29,59 @@ PARAMETER_RENAME_MAP: dict[str, str] = {
     "relhum_2m": internal.OCFShortName.RelativeHumidityAGL.value,
     "u_10m": internal.OCFShortName.WindUComponentAGL.value,
     "v_10m": internal.OCFShortName.WindVComponentAGL.value,
-    "clat": "lat", # Icon has a seperate dataset for latitude...
-    "clon": "lon", # ... and longitude (for the global model)! Go figure
+    "clat": "lat",  # Icon has a seperate dataset for latitude...
+    "clon": "lon",  # ... and longitude (for the global model)! Go figure
 }
 
-COORDINATE_ALLOW_LIST: typing.Sequence[str] = (
-    "time", "step", "latitude", "longitude"
-)
+COORDINATE_ALLOW_LIST: typing.Sequence[str] = ("time", "step", "latitude", "longitude")
+
 
 class Client(internal.FetcherInterface):
     """Implements a client to fetch ICON data from DWD."""
 
-    baseurl: str
-    model: str
+    baseurl: str  # The base URL for the ICON model
+    model: str  # The model to fetch data for
+    parameters: list[str]  # The parameters to fetch
+    conform: bool  # Whether to rename parameters to OCF names and clear unwanted coordinates
 
-    def __init__(self, model: str) -> None:
-        """Create a new client."""
+    def __init__(self, model: str, param_group: str | None = "default") -> None:
+        """Create a new client.
+
+        Parameters
+        ----------
+        model: The model to fetch data for. Valid models are "europe" and "global".
+        param_group: The set of parameters to fetch. Valid groups are "default" and "full".
+        """
+
         self.baseurl = "https://opendata.dwd.de/weather/nwp"
         self.model = model
 
         match model:
-            case "europe": self.baseurl += "/icon-eu/grib"
-            case "global": self.baseurl += "/icon/grib"
-            case _: raise ValueError(f"unknown icon model {model}. Valid models are 'europe' and 'global'")
+            case "europe":
+                self.baseurl += "/icon-eu/grib"
+            case "global":
+                self.baseurl += "/icon/grib"
+            case _:
+                raise ValueError(
+                    f"unknown icon model {model}. Valid models are 'europe' and 'global'"
+                )
+
+        match (param_group, model):
+            case ("default", _):
+                self.parameters = [k for k, _ in PARAMETER_RENAME_MAP.items()]
+                self.conform = True
+            case ("full", "europe"):
+                self.parameters = EU_SL_VARS + EU_ML_VARS
+                self.conform = False
+            case ("full", "global"):
+                self.parameters = GLOBAL_SL_VARS + GLOBAL_ML_VARS + ["clat", "clon"]
+                self.conform = False
+            case (_, _):
+                raise ValueError(
+                    f"unknown parameter group {param_group}. Valid groups are 'default' and 'full'"
+                )
 
     def listRawFilesForInitTime(self, *, it: dt.datetime) -> list[internal.FileInfoModel]:  # noqa: D102
-
         # ICON data is only available for today's date. If data hasn't been uploaded for that init
         # time yet, then yesterday's data will still be present on the server.
         if it.date() != dt.datetime.now(dt.timezone.utc).date():
@@ -67,11 +95,11 @@ class Client(internal.FetcherInterface):
         files: list[internal.FileInfoModel] = []
 
         # Files are split per parameter, level, and step, with a webpage per parameter
-        for param, _ in PARAMETER_RENAME_MAP.items():
-
-            if self.model == "europe" and (param == "clat" or param == "clon"):
-                # The latitude and longitude files are not available for the EU model
-                continue
+        # * The webpage contains a list of files for the parameter
+        # * Find these files for each parameter and add them to the list
+        for param in self.parameters:
+            # The list of files for the parameter
+            parameterFiles: list[internal.FileInfoModel] = []
 
             # Fetch DWD webpage detailing the available files for the parameter
             response = requests.get(f"{self.baseurl}/{it.strftime('%H')}/{param}/", timeout=3)
@@ -82,7 +110,7 @@ class Client(internal.FetcherInterface):
                     status=response.status_code,
                     url=response.url,
                     param=param,
-                    init_time=it.strftime("%Y-%m-%d %H:%M"),
+                    inittime=it.strftime("%Y-%m-%d %H:%M"),
                 )
                 continue
 
@@ -90,44 +118,42 @@ class Client(internal.FetcherInterface):
             # * Each <a> tag has a href, most of which point to a file)
             for line in response.text.splitlines():
 
-                # Check if the line contains a href
-                refmatch = re.search(r'href="(.+)">', line)
-                if refmatch:
-                    # Try to extract file information from the href.
+                # Check if the line contains a href, if not, skip it
+                refmatch = re.search(pattern=r'href="(.+)">', string=line)
+                if refmatch == None:
+                    continue
 
-                    # First match the single level files and extract the datetime, step, and parameter.
-                    # Their file links are formatted as follows, where L is level and X is step:
-                    #   * icon_MODEL_single-level_YYYYDDMMHH_XXX_SOME_PARAM.grib2.bz2
-                    slmatch = re.search(r'single-level_(\d{10})_(\d{3})_([A-Za-z_\d]+).grib', line)
-                    if slmatch:
-                        itstring, stepstring, paramstring = slmatch.groups()
-                        # Ignore the file if it is not for today's date or has a step > 48
-                        if (itstring != it.strftime("%Y%m%d%H")) or (stepstring > "048"):
-                            continue
-                        files.append(IconFileInfo(
-                            it=dt.datetime.strptime(itstring, "%Y%m%d%H"),
-                            filename=refmatch.groups()[0],
-                            currentURL=f"{self.baseurl}/{it.strftime('%H')}/{param}",
-                        ))
+                # The href contains the name of a file - parse this into a FileInfo object
+                fi: IconFileInfo | None = None
+                # If not conforming, match all files
+                # * Otherwise only match single level and time invariant
+                fi = _parseIconFilename(
+                    name=refmatch.groups()[0],
+                    baseurl=self.baseurl,
+                    match_ml=not self.conform,
+                    match_pl=not self.conform,
+                )
+                # Ignore the file if it is not for today's date or has a step > 48 (when conforming)
+                if (fi == None or fi.it() != it or (fi.step > 48 and self.conform)):
+                    continue
 
-                    # Next match time-invariant files and extract as before.
-                    # Time invariant files are formatted as follows:
-                    # * icon_MODEL_time-invariant_YYYYDDMMHH_SOME_PARAM.grib2.bz2
-                    timatch = re.search(r'time-invariant_(\d{10})_([A-Za-z_\d]+).grib', line)
-                    if timatch:
-                        itstring, paramstring = timatch.groups()
-                        if itstring != it.strftime("%Y%m%d%H"):
-                            continue
-                        files.append(IconFileInfo(
-                            it=dt.datetime.strptime(itstring, "%Y%m%d%H"),
-                            filename=refmatch.groups()[0],
-                            currentURL=f"{self.baseurl}/{it.strftime('%H')}/{param}",
-                        ))
+                # Add the file to the list
+                parameterFiles.append(fi)
+
+            log.debug(
+                event="listed files for parameter",
+                param=param,
+                inittime=it.strftime("%Y-%m-%d %H:%M"),
+                url=response.url,
+                numfiles=len(parameterFiles),
+            )
+
+            files.append(parameterFiles)
 
         return files
 
     def mapTemp(self, *, p: pathlib.Path) -> xr.Dataset:  # noqa: D102
-        if p.suffix != '.grib2':
+        if p.suffix != ".grib2":
             log.warn(
                 event="cannot map non-grib file to dataset",
                 filepath=p.as_posix(),
@@ -138,10 +164,7 @@ class Client(internal.FetcherInterface):
             # Ignore the latitude and longitude files
             return xr.Dataset()
 
-        log.debug(
-            event="mapping raw file to xarray dataset",
-            filepath=p.as_posix()
-        )
+        log.debug(event="mapping raw file to xarray dataset", filepath=p.as_posix())
 
         # Load the raw file as a dataset
         try:
@@ -164,17 +187,18 @@ class Client(internal.FetcherInterface):
             )
             return xr.Dataset()
 
-        # Rename the parameters to the OCF names
-        # * Only do so if they exist in the dataset
-        for oldParamName, newParamName in PARAMETER_RENAME_MAP.items():
-            if oldParamName in ds:
-                ds = ds.rename({oldParamName: newParamName})
+        # Only conform the dataset if requested (defaults to True)
+        if self.conform:
+            # Rename the parameters to the OCF names
+            # * Only do so if they exist in the dataset
+            for oldParamName, newParamName in PARAMETER_RENAME_MAP.items():
+                if oldParamName in ds:
+                    ds = ds.rename({oldParamName: newParamName})
 
-        # Delete unwanted coordinates
-        ds = ds.drop_vars(
-            names=[c for c in ds.coords if c not in COORDINATE_ALLOW_LIST],
-            errors="ignore"
-        )
+            # Delete unwanted coordinates
+            ds = ds.drop_vars(
+                names=[c for c in ds.coords if c not in COORDINATE_ALLOW_LIST], errors="ignore"
+            )
 
         # Inject latitude and longitude into the dataset if they are missing
         if "latitude" not in ds:
@@ -213,29 +237,30 @@ class Client(internal.FetcherInterface):
 
         # Create chunked Dask dataset with a single "variable" dimension
         # * Each chunk is a single time step
-        ds = ds \
-            .rename({"time": "init_time"}) \
-            .expand_dims("init_time") \
-            .expand_dims("step") \
-            .to_array(dim="variable", name=f"ICON_{self.model}".upper()) \
-            .to_dataset() \
-            .transpose("variable", "init_time", "step", ...) \
-            .sortby("step") \
-            .sortby("variable") \
-            .chunk({
-                "init_time": 1,
-                "step": -1,
-                "variable": -1,
-            })
+        ds = (
+            ds.rename({"time": "init_time"})
+            .expand_dims("init_time")
+            .expand_dims("step")
+            .to_array(dim="variable", name=f"ICON_{self.model}".upper())
+            .to_dataset()
+            .transpose("variable", "init_time", "step", ...)
+            .sortby("step")
+            .sortby("variable")
+            .chunk(
+                {
+                    "init_time": 1,
+                    "step": -1,
+                    "variable": -1,
+                }
+            )
+        )
 
         return ds
 
-    def downloadToTemp(self, *, fi: internal.FileInfoModel) -> tuple[internal.FileInfoModel, pathlib.Path]:  # noqa: D102
-        log.debug(
-            event="requesting download of file",
-            file=fi.filename(),
-            path=fi.filepath()
-        )
+    def downloadToTemp(
+        self, *, fi: internal.FileInfoModel
+    ) -> tuple[internal.FileInfoModel, pathlib.Path]:  # noqa: D102
+        log.debug(event="requesting download of file", file=fi.filename(), path=fi.filepath())
         try:
             response = urllib.request.urlopen(fi.filepath())
         except Exception as e:
@@ -243,7 +268,7 @@ class Client(internal.FetcherInterface):
                 event="error calling url for file",
                 url=fi.filepath(),
                 filename=fi.filename(),
-                error=e
+                error=e,
             )
             return fi, pathlib.Path()
 
@@ -252,7 +277,7 @@ class Client(internal.FetcherInterface):
                 event="error downloading file",
                 status=response.status,
                 url=fi.filepath(),
-                filename=fi.filename()
+                filename=fi.filename(),
             )
             return fi, pathlib.Path()
 
@@ -260,7 +285,7 @@ class Client(internal.FetcherInterface):
         tfp: pathlib.Path = internal.TMP_DIR / fi.filename()
         with open(tfp, "wb") as f:
             dec = bz2.BZ2Decompressor()
-            for chunk in iter(lambda: response.read(16 * 1024), b''):
+            for chunk in iter(lambda: response.read(16 * 1024), b""):
                 f.write(dec.decompress(chunk))
                 f.flush()
 
@@ -269,8 +294,67 @@ class Client(internal.FetcherInterface):
             filename=fi.filename(),
             url=fi.filepath(),
             filepath=tfp.as_posix(),
-            nbytes=tfp.stat().st_size
+            nbytes=tfp.stat().st_size,
         )
 
         return fi, tfp
 
+
+def _parseIconFilename(
+    name: str,
+    baseurl: str,
+    match_sl: bool | None = True,
+    match_ti: bool | None = True,
+    match_ml: bool | None = False,
+    match_pl: bool | None = False,
+) -> IconFileInfo | None:
+    """Parse a string of HTML into an IconFileInfo object, if it contains one.
+
+    Parameters
+    ----------
+    name: The name of the file to parse
+    baseurl: The base URL for the ICON model
+    match_sl: Whether to match single-level files
+    match_ti: Whether to match time-invariant files
+    match_ml: Whether to match model-level files
+    match_pl: Whether to match pressure-level files
+    """
+
+
+    # Define the regex patterns to match the different types of file; X is step, L is level
+    # * Single Level: `MODEL_single-level_YYYYDDMMHH_XXX_SOME_PARAM.grib2.bz2`
+    slRegex = r"single-level_(\d{10})_(\d{3})_([A-Za-z_\d]+).grib"
+    # * Time Invariant: `MODEL_time-invariant_YYYYDDMMHH_SOME_PARAM.grib2.bz2`
+    tiRegex = r"time-invariant_(\d{10})_([A-Za-z_\d]+).grib"
+    # * Model Level: `MODEL_model-level_YYYYDDMMHH_XXX_LLL_SOME_PARAM.grib2.bz2`
+    mlRegex = r"model-level_(\d{10})_(\d{3})_(\d+)_([A-Za-z_\d]+).grib"
+    # * Pressure Level: `MODEL_pressure-level_YYYYDDMMHH_XXX_LLLL_SOME_PARAM.grib2.bz2`
+    plRegex = r"pressure-level_(\d{10})_(\d{3})_(\d+)_([A-Za-z_\d]+).grib"
+
+    itstring = paramstring = ""
+    stepstring = "000"
+    # Try to match the href to one of the regex patterns
+    slmatch = re.search(pattern=slRegex, string=name)
+    timatch = re.search(pattern=tiRegex, string=name)
+    mlmatch = re.search(pattern=mlRegex, string=name)
+    plmatch = re.search(pattern=plRegex, string=name)
+
+    if (slmatch and match_sl):
+        itstring, stepstring, paramstring = slmatch.groups()
+    elif (timatch and match_ti):
+        itstring, paramstring = timatch.groups()
+    elif (mlmatch and match_ml):
+        itstring, stepstring, levelstring, paramstring = mlmatch.groups()
+    elif (plmatch and match_pl):
+        itstring, stepstring, levelstring, paramstring = plmatch.groups()
+    else:
+        return None
+
+    it = dt.datetime.strptime(itstring, "%Y%m%d%H")
+
+    return IconFileInfo(
+        it=it,
+        filename=name,
+        currentURL=f"{baseurl}/{it.strftime('%H')}/{paramstring.lower()}/",
+        step=int(stepstring),
+    )

--- a/src/nwp_consumer/internal/inputs/icon/test_client.py
+++ b/src/nwp_consumer/internal/inputs/icon/test_client.py
@@ -2,7 +2,8 @@ import datetime as dt
 import pathlib
 import unittest
 
-from .client import PARAMETER_RENAME_MAP, Client
+from .client import PARAMETER_RENAME_MAP, Client, _parseIconFilename
+from ._models import IconFileInfo
 
 testClient = Client(model='global')
 
@@ -34,4 +35,73 @@ class TestClient(unittest.TestCase):
         self.assertEqual(out[list(out.data_vars.keys())[0]].dims, ('variable', 'init_time', 'step', 'latitude', 'longitude'))
         # Check that the parameter is renamed
         self.assertEqual(out["variable"].values[0], "ccl")
+
+
+class TestParseIconFilename(unittest.TestCase):
+
+    baseurl = "https://opendata.dwd.de/weather/nwp/icon/grib"
+
+    def test_parsesSingleLevel(self):
+
+        filename: str = "icon_global_icosahedral_single-level_2020090100_000_T_HUM.grib2.bz2"
+
+        out: IconFileInfo | None  = _parseIconFilename(
+            name=filename,
+            baseurl=self.baseurl
+        )
+        self.assertIsNotNone(out)
+        self.assertEqual(out.filename(), filename.removesuffix(".bz2"))
+        self.assertEqual(out.it(), dt.datetime(2020, 9, 1, 0))
+
+    def test_parsesTimeInvariant(self):
+
+        filename: str = "icon_global_icosahedral_time-invariant_2020090100_CLAT.grib2.bz2"
+
+        out: IconFileInfo | None  = _parseIconFilename(
+            name=filename,
+            baseurl=self.baseurl
+        )
+        self.assertIsNotNone(out)
+        self.assertEqual(out.filename(), filename.removesuffix(".bz2"))
+        self.assertEqual(out.it(), dt.datetime(2020, 9, 1, 0))
+
+    def test_parsesModelLevel(self):
+
+        filename: str = "icon_global_icosahedral_model-level_2020090100_048_32_CLCL.grib2.bz2"
+
+        out: IconFileInfo | None  = _parseIconFilename(
+            name=filename,
+            baseurl=self.baseurl,
+            match_ml=True
+        )
+        self.assertIsNotNone(out)
+        self.assertEqual(out.filename(), filename.removesuffix(".bz2"))
+        self.assertEqual(out.it(), dt.datetime(2020, 9, 1, 0))
+
+        out: IconFileInfo | None = _parseIconFilename(
+            name=filename,
+            baseurl=self.baseurl,
+            match_ml=False
+        )
+        self.assertIsNone(out)
+
+    def test_parsesPressureLevel(self):
+
+        filename: str = "icon_global_icosahedral_pressure-level_2020090100_048_1000_T.grib2.bz2"
+
+        out: IconFileInfo | None = _parseIconFilename(
+            name=filename,
+            baseurl=self.baseurl,
+            match_pl=True
+        )
+        self.assertIsNotNone(out)
+        self.assertEqual(out.filename(), filename.removesuffix(".bz2"))
+        self.assertEqual(out.it(), dt.datetime(2020, 9, 1, 0))
+        
+        out: IconFileInfo | None  = _parseIconFilename(
+            name=filename,
+            baseurl=self.baseurl,
+            match_pl=False
+        )
+        self.assertIsNone(out)
 

--- a/src/test_integration/test_inputs_integration.py
+++ b/src/test_integration/test_inputs_integration.py
@@ -74,7 +74,8 @@ class TestClient_FetchRawFileBytes(unittest.TestCase):
         fileInfo = IconFileInfo(
             it=iconInitTime,
             filename=f"icon_global_icosahedral_single-level_{iconInitTime.strftime('%Y%m%d%H')}_001_CLCL.grib2.bz2",
-            currentURL="https://opendata.dwd.de/weather/nwp/icon/grib/00/clcl"
+            currentURL="https://opendata.dwd.de/weather/nwp/icon/grib/00/clcl",
+            step=1
         )
         _, tmpPath = iconClient.downloadToTemp(fi=fileInfo)
         self.assertFalse(tmpPath.name.endswith(".bz2"))
@@ -87,7 +88,8 @@ class TestClient_FetchRawFileBytes(unittest.TestCase):
         fileInfo = IconFileInfo(
             it=iconInitTime,
             filename=f"icon-eu_europe_regular-lat-lon_single-level_{iconInitTime.strftime('%Y%m%d%H')}_001_CLCL.grib2.bz2",
-            currentURL="https://opendata.dwd.de/weather/nwp/icon-eu/grib/00/clcl"
+            currentURL="https://opendata.dwd.de/weather/nwp/icon-eu/grib/00/clcl",
+            step=1
         )
         _, tmpPath = iconClient.downloadToTemp(fi=fileInfo)
         self.assertGreater(tmpPath.stat().st_size, 40000)


### PR DESCRIPTION
Normally the NWP consumer conforms the data sources it pulls from to have matching sets of parameters with consistent naming. However, it is desired that it can be used to pull the entire database of icon files, regardless of whether they are part of the usual subset of variables. This PR enables such functionality.