### PR TITLE
Create basic parametersets for shorter integration testing

### DIFF
--- a/src/nwp_consumer/cmd/main.py
+++ b/src/nwp_consumer/cmd/main.py
@@ -102,6 +102,7 @@ def run(arguments: dict) -> tuple[list[pathlib.Path], list[pathlib.Path]]:
             fetcher = inputs.ecmwf.mars.Client(
                 area=env.ECMWF_AREA,
                 hours=env.ECMWF_HOURS,
+                param_group=env.ECMWF_PARAMETER_GROUP,
             )
         case "icon":
             env = config.ICONEnv()

--- a/src/nwp_consumer/internal/config/env.py
+++ b/src/nwp_consumer/internal/config/env.py
@@ -56,6 +56,7 @@ class ECMWFMARSEnv(EnvParser):
     ECMWF_API_EMAIL: str
     ECMWF_AREA: str = "uk"
     ECMWF_HOURS: str = "48"
+    ECMWF_PARAMETER_GROUP: str = "default"
 
 class ICONEnv(EnvParser):
     """Config for ICON API."""

--- a/src/nwp_consumer/internal/inputs/icon/client.py
+++ b/src/nwp_consumer/internal/inputs/icon/client.py
@@ -50,7 +50,7 @@ class Client(internal.FetcherInterface):
         Parameters
         ----------
         model: The model to fetch data for. Valid models are "europe" and "global".
-        param_group: The set of parameters to fetch. Valid groups are "default" and "full".
+        param_group: The set of parameters to fetch. Valid groups are "default", "full", and "basic".
         """
 
         self.baseurl = "https://opendata.dwd.de/weather/nwp"
@@ -68,7 +68,10 @@ class Client(internal.FetcherInterface):
 
         match (param_group, model):
             case ("default", _):
-                self.parameters = [k for k, _ in PARAMETER_RENAME_MAP.items()]
+                self.parameters = list(PARAMETER_RENAME_MAP.keys())
+                self.conform = True
+            case ("basic", _):
+                self.parameters = ["asob_s", "clcl", "clon", "clat"]
                 self.conform = True
             case ("full", "europe"):
                 self.parameters = EU_SL_VARS + EU_ML_VARS
@@ -78,7 +81,7 @@ class Client(internal.FetcherInterface):
                 self.conform = False
             case (_, _):
                 raise ValueError(
-                    f"unknown parameter group {param_group}. Valid groups are 'default' and 'full'"
+                    f"unknown parameter group {param_group}. Valid groups are 'default', 'full', 'basic'"
                 )
 
     def listRawFilesForInitTime(self, *, it: dt.datetime) -> list[internal.FileInfoModel]:  # noqa: D102

--- a/src/test_integration/test_service_integration.py
+++ b/src/test_integration/test_service_integration.py
@@ -119,10 +119,12 @@ class TestNWPConsumerService_CEDA(unittest.TestCase):
 class TestNWPConverterService_ECMWFMARS(unittest.TestCase):
     def setUp(self):
         storageClient = outputs.localfs.Client()
-        env = config.ECMWFMARSEnv()
+
+        # Test downloading the basic parameter set for the UK model
         ecmwfMarsClient = inputs.ecmwf.mars.Client(
-            area=env.ECMWF_AREA,
-            hours=env.ECMWF_HOURS,
+            area="uk",
+            hours="4",
+            param_group="basic",
         )
 
         self.rawdir = 'data/ec_raw'
@@ -151,7 +153,7 @@ class TestNWPConverterService_ECMWFMARS(unittest.TestCase):
             self.assertEqual(["ECMWF_UK"], list(ds.data_vars))
             # Ensure the dimensions have the right sizes
             self.assertEqual(
-                {'variable': 17, 'init_time': 1, 'step': 49, 'latitude': 241, 'longitude': 301},
+                {'variable': 2, 'init_time': 1, 'step': 5, 'latitude': 241, 'longitude': 301},
                 dict(ds.dims.items())
             )
             # Ensure the init time is correct
@@ -166,9 +168,11 @@ class TestNWPConsumerService_ICON(unittest.TestCase):
 
     def setUp(self) -> None:
         storageClient = outputs.localfs.Client()
-        env = config.ICONEnv()
+
+        # Test downloading the basic parameter set for the global model
         iconClient = inputs.icon.Client(
-            model="globallen(out)
+            model="global",
+            param_group="basic",
         )
 
         self.rawdir = 'data/ic_raw'
@@ -197,7 +201,7 @@ class TestNWPConsumerService_ICON(unittest.TestCase):
             self.assertEqual(["ICON_GLOBAL"], list(ds.data_vars))
             # Ensure the dimensions have the right sizes
             self.assertEqual(
-                {'variable': 10, 'init_time': 1, 'step': 37, 'values': 2200999},
+                {'variable': 2, 'init_time': 1, 'step': 49, 'values': 2200999},
                 dict(ds.dims.items())
             )
             # Ensure the init time is correct


### PR DESCRIPTION
Integration tests currently timeout on github runners due to testing download of entire daily datasets. This PR implements a the idea of a "parameter group" to source clients that can be set to "default" or "basic". "basic" only requests a small subset of parameters to speed up the total time of the integration test.