### PR TITLE
Make storing single-threaded to fix hugginface commit issues

### DIFF
--- a/src/nwp_consumer/internal/outputs/huggingface/client.py
+++ b/src/nwp_consumer/internal/outputs/huggingface/client.py
@@ -8,8 +8,6 @@ import structlog
 from huggingface_hub.hf_api import (
     RepoFile,
     RepoFolder,
-    RepositoryNotFoundError,
-    EntryNotFoundError,
     RevisionNotFoundError,
 )
 
@@ -52,7 +50,9 @@ class Client(internal.StorageInterface):
         self.repoID = repoID
 
         try:
-            self.__api.dataset_info(repo_id=self.datasetPath.relative_to("datasets").as_posix())
+            self.__api.dataset_info(
+                repo_id=repoID,
+            )
         except Exception as e:
             log.warn(
                 event="failed to authenticate with huggingface for given repo",
@@ -252,7 +252,7 @@ class Client(internal.StorageInterface):
         """Gets the size of a file or folder in the huggingface dataset."""
         size: int = 0
 
-        # Determine if the path corresponds to a file or a folder
+        # Get the info of the path
         path_info: RepoFile | RepoFolder = self.__api.get_paths_info(
             repo_id=self.repoID,
             repo_type="dataset",

--- a/src/nwp_consumer/internal/service/service.py
+++ b/src/nwp_consumer/internal/service/service.py
@@ -177,7 +177,7 @@ class NWPConsumerService:
             .filter(_dataQualityFilter)
             .map(lambda ds: _saveAsTempZipZarr(ds=ds))
             .map(lambda path: self.storer.store(src=path, dst=self.zarrdir / path.name))
-            .compute(num_workers=1)
+            .compute(scheduler="single-threaded")
         )  # AWS ECS only has 1 CPU which amounts to half a physical core
 
         if not isinstance(storedfiles, list):


### PR DESCRIPTION
Huggingface does not like simulaneous file pushes as it is a version-contril based system thta checks the head commit hasn't changed before every push. Since this process is not time-critical, revert it to be done in a single-threaded manner.