### PR TITLE
Guard against absolute paths in huggingface

### DIFF
--- a/src/nwp_consumer/cmd/main.py
+++ b/src/nwp_consumer/cmd/main.py
@@ -13,7 +13,7 @@ Commands:
   download            Download raw data from source to sink
   convert             Convert raw data present in sink
   consume             Download and convert raw data from source to sink
-  check               Perform a healthcheck.py on the service
+  check               Perform a healthcheck on the service
   env                 Print the unset environment variables required by the source/sink
 
 Options:

--- a/src/nwp_consumer/internal/outputs/huggingface/client.py
+++ b/src/nwp_consumer/internal/outputs/huggingface/client.py
@@ -77,6 +77,9 @@ class Client(internal.StorageInterface):
 
     def store(self, *, src: pathlib.Path, dst: pathlib.Path) -> pathlib.Path:
         """Overrides the corresponding method of the parent class."""
+        # Remove any leading slashes as they are not allowed in huggingface
+        dst = dst.relative_to("/") if dst.is_absolute() else dst
+
         # Get the hash of the latest commit
         sha: str = self.__api.dataset_info(repo_id=self.repoID).sha
         # Handle the case where we are trying to upload a folder
@@ -126,6 +129,8 @@ class Client(internal.StorageInterface):
 
     def listInitTimes(self, *, prefix: pathlib.Path) -> list[dt.datetime]:
         """Overrides the corresponding method of the parent class."""
+        # Remove any leading slashes as they are not allowed in huggingface
+        prefix = prefix.relative_to("/") if prefix.is_absolute() else prefix
         # Get the path relative to the prefix of every folder in the repo
         allDirs: list[pathlib.Path] = [
             pathlib.Path(f.path).relative_to(prefix)
@@ -166,6 +171,10 @@ class Client(internal.StorageInterface):
 
     def copyITFolderToTemp(self, *, prefix: pathlib.Path, it: dt.datetime) -> list[pathlib.Path]:
         """Overrides the corresponding method of the parent class."""
+        # Remove any leading slashes as they are not allowed in huggingface
+        prefix = prefix.relative_to("/") if prefix.is_absolute() else prefix
+
+        # Get the paths of all files in the folder
         paths: list[RepoFile] = [
             p
             for p in self.__api.list_repo_tree(
@@ -238,6 +247,9 @@ class Client(internal.StorageInterface):
 
     def delete(self, *, p: pathlib.Path) -> None:
         """Overrides the corresponding method of the parent class."""
+        # Remove any leading slashes as they are not allowed in huggingface
+        p = p.relative_to("/") if p.is_absolute() else p
+
         # Determine if the path corresponds to a file or a folder
         info: RepoFile | RepoFolder = self.__api.get_paths_info(
             repo_id=self.repoID,
@@ -261,8 +273,10 @@ class Client(internal.StorageInterface):
 
     def _get_size(self, *, p: pathlib.Path) -> int:
         """Gets the size of a file or folder in the huggingface dataset."""
-        size: int = 0
+        # Remove any leading slashes as they are not allowed in huggingface
+        p = p.relative_to("/") if p.is_absolute() else p
 
+        size: int = 0
         # Get the info of the path
         path_info: RepoFile | RepoFolder = self.__api.get_paths_info(
             repo_id=self.repoID,

--- a/src/nwp_consumer/internal/outputs/huggingface/client.py
+++ b/src/nwp_consumer/internal/outputs/huggingface/client.py
@@ -22,9 +22,6 @@ class Client(internal.StorageInterface):
     # HuggingFace API
     __api: hfh.HfApi
 
-    # Path prefix
-    datasetPath: pathlib.Path
-
     # DatasetURL
     dsURL: str
 
@@ -169,13 +166,12 @@ class Client(internal.StorageInterface):
 
     def copyITFolderToTemp(self, *, prefix: pathlib.Path, it: dt.datetime) -> list[pathlib.Path]:
         """Overrides the corresponding method of the parent class."""
-        initTimeDirPath = self.datasetPath / prefix / it.strftime(internal.IT_FOLDER_FMTSTR)
         paths: list[RepoFile] = [
             p
             for p in self.__api.list_repo_tree(
                 repo_id=self.repoID,
                 repo_type="dataset",
-                path_in_repo=initTimeDirPath.as_posix(),
+                path_in_repo=(prefix / it.strftime(internal.IT_FOLDER_FMTSTR)).as_posix(),
                 recursive=True,
             )
             if isinstance(p, RepoFile)
@@ -276,7 +272,10 @@ class Client(internal.StorageInterface):
 
         if len(path_info) == 0:
             # The path in question doesn't exist
-            log.warn("here")
+            log.warn(
+                event="path does not exist in huggingface dataset",
+                path=p.as_posix(),
+            )
             return size
 
         # Calculate the size of the file or folder

--- a/src/nwp_consumer/internal/service/service.py
+++ b/src/nwp_consumer/internal/service/service.py
@@ -72,7 +72,7 @@ class NWPConsumerService:
                 start=start,
                 end=end,
                 inclusive="left",
-                freq="H",
+                freq="h",
                 tz=dt.UTC,
             ).tolist()
             if pdt.to_pydatetime().hour in self.fetcher.getInitHours()

--- a/src/test_integration/test_service_integration.py
+++ b/src/test_integration/test_service_integration.py
@@ -188,7 +188,7 @@ class TestNWPConsumerService_ICON(unittest.TestCase):
             # * Should be two variables due to the "basic" parameter group
             # * Should be 4 steps due to the "3" hours
             self.assertEqual(
-                {"variable": 2, "init_time": 1, "step": 4, "values": 2949120},
+                {"variable": 2, "init_time": 1, "step": 4, "latitude": 657, "longitude": 1377},
                 dict(ds.dims.items()),
             )
             # Ensure the init time is correct


### PR DESCRIPTION
Huggingface uploads files when given an absolute path but is unable to find said files when given the same path. As such, remove the possibility of adding leading slashes to any paths being stored in huggingface.