### PR TITLE
Explicitly open temp file for writing and close before reading

### DIFF
--- a/src/nwp_consumer/internal/outputs/huggingface/client.py
+++ b/src/nwp_consumer/internal/outputs/huggingface/client.py
@@ -217,7 +217,7 @@ class Client(internal.StorageInterface):
 
             # Copy the file from the store to a temporary file
             self.__api.hf_hub_download(
-                repoID=self.repoID,
+                repo_id=self.repoID,
                 repo_type="dataset",
                 filename=path.as_posix(),
                 local_dir=internal.TMP_DIR.as_posix(),


### PR DESCRIPTION
Ensure hanging isn't occuring at read time on ECMWF temporary file