### PR TITLE
Ensure huggingface stores temporary files in the right location

### DIFF
--- a/src/nwp_consumer/internal/outputs/huggingface/test_client.py
+++ b/src/nwp_consumer/internal/outputs/huggingface/test_client.py
@@ -1,5 +1,8 @@
+import datetime as dt
 import pathlib
 import unittest
+
+from nwp_consumer import internal
 
 from .client import Client
 
@@ -38,13 +41,3 @@ class TestHuggingFaceClient(unittest.TestCase):
             with self.subTest(msg=name):
                 self.assertEqual(self.client.exists(dst=pathlib.Path(name)), exp)
 
-    def test_download(self) -> None:
-        client = Client(repoID="sol-ocf/test-dwd-global")
-        client.__api.hf_hub_download(
-            repo_id=self.repoID,
-            repo_type="dataset",
-            filename="raw/2024/02/05/0000/icon_global_icosahedral_single-level_2024020500_000_ASOB_S.grib2",
-            local_dir=internal.TMP_DIR.as_posix(),
-            local_dir_use_symlinks=False,
-            force_filename=,
-        )

--- a/src/nwp_consumer/internal/outputs/huggingface/test_client.py
+++ b/src/nwp_consumer/internal/outputs/huggingface/test_client.py
@@ -38,3 +38,13 @@ class TestHuggingFaceClient(unittest.TestCase):
             with self.subTest(msg=name):
                 self.assertEqual(self.client.exists(dst=pathlib.Path(name)), exp)
 
+    def test_download(self) -> None:
+        client = Client(repoID="sol-ocf/test-dwd-global")
+        client.__api.hf_hub_download(
+            repo_id=self.repoID,
+            repo_type="dataset",
+            filename="raw/2024/02/05/0000/icon_global_icosahedral_single-level_2024020500_000_ASOB_S.grib2",
+            local_dir=internal.TMP_DIR.as_posix(),
+            local_dir_use_symlinks=False,
+            force_filename=,
+        )

--- a/src/nwp_consumer/internal/service/service.py
+++ b/src/nwp_consumer/internal/service/service.py
@@ -101,7 +101,7 @@ class NWPConsumerService:
             log.info(
                 event="no new files to download",
                 startDate=start.strftime("%Y-%m-%d %H:%M"),
-                endDate=end.strftime("%Y-%m-%d %H:%M"),
+               endDate=end.strftime("%Y-%m-%d %H:%M"),
             )
             return [
                 self.rawdir / fi.it().strftime(internal.IT_FOLDER_FMTSTR) / fi.filename()


### PR DESCRIPTION
Huggingface cannot download a single file to a path you want - rather, it recreates the path within the repo in a directory of your specifying. This commit ensures that those paths are specified when dealing with downloaded files from huggingface.