### PR TITLE
Add quotation for pip install dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Note that these are the bare dependencies for running the application. If you wa
 you need the development dependencies as well, which can be installed via
 
 ```shell
-$ pip install -e .[dev]
+$ pip install -e ".[dev]"
 ```
 
 or


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes an issue with `pip install -e .[dev]` throwing an error when using zsh on MacOS. See https://github.com/mu-editor/mu/issues/852 for more details about the problem.

## How Has This Been Tested?

Install dev dependencies on a mac using `pip install -e ".[dev]"` does not throw an error.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings

*I marked tasks that are not applicable as checked.*