### PR TITLE
Enable using dask distributed client via configuration

### DIFF
--- a/src/nwp_consumer/internal/config/__init__.py
+++ b/src/nwp_consumer/internal/config/__init__.py
@@ -3,6 +3,7 @@
 __all__ = [
     "EnvParser",
     "CEDAEnv",
+    "ConsumerEnv",
     "CMCEnv",
     "ECMWFMARSEnv",
     "ICONEnv",
@@ -15,6 +16,7 @@ __all__ = [
 from .env import (
     CEDAEnv,
     CMCEnv,
+    ConsumerEnv,
     ECMWFMARSEnv,
     EnvParser,
     HuggingFaceEnv,

--- a/src/nwp_consumer/internal/config/env.py
+++ b/src/nwp_consumer/internal/config/env.py
@@ -53,6 +53,14 @@ class EnvParser:
                     self.__setattr__(field, t(env_value))
 
 
+# --- Configuration environment variables --- #
+
+class ConsumerEnv(EnvParser):
+    """Config for Consumer."""
+
+    DASK_SCHEDULER_ADDRESS: str = ""
+
+
 # --- Inputs environment variables --- #
 
 

--- a/src/nwp_consumer/internal/inputs/ceda/client.py
+++ b/src/nwp_consumer/internal/inputs/ceda/client.py
@@ -310,9 +310,9 @@ def _reshapeTo2DGrid(*, ds: xr.Dataset) -> xr.Dataset:
     northing = np.arange(start=maxY, stop=minY, step=-dy, dtype=np.int32)
     easting = np.arange(start=minX, stop=maxX, step=dx, dtype=np.int32)
 
-    if ds.dims["values"] != len(northing) * len(easting):
+    if ds.sizes["values"] != len(northing) * len(easting):
         raise ValueError(
-            f"dataset has {ds.dims['values']} values, "
+            f"dataset has {ds.sizes['values']} values, "
             f"but expected {len(northing) * len(easting)}",
         )
 

--- a/src/nwp_consumer/internal/inputs/ceda/test_client.py
+++ b/src/nwp_consumer/internal/inputs/ceda/test_client.py
@@ -41,7 +41,7 @@ class TestClient_MapTemp(unittest.TestCase):
         # Ensure the dimensions have the right sizes
         self.assertDictEqual(
             {"init_time": 1, "variable": 6, "step": 4, "y": 704, "x": 548},
-            dict(out.dims.items()),
+            dict(out.sizes.items()),
         )
         # Ensure the dimensions of the variables are in the correct order
         self.assertEqual(("variable", "init_time", "step", "y", "x"), out["UKV"].dims)
@@ -59,7 +59,7 @@ class TestClient_MapTemp(unittest.TestCase):
         # Ensure the dimensions have the right sizes
         self.assertDictEqual(
             {"init_time": 1, "variable": 6, "step": 4, "y": 704, "x": 548},
-            dict(out.dims.items()),
+            dict(out.sizes.items()),
         )
         # Ensure the dimensions of the variables are in the correct order
         self.assertEqual(("variable", "init_time", "step", "y", "x"), out["UKV"].dims)

--- a/src/nwp_consumer/internal/inputs/ecmwf/test_mars.py
+++ b/src/nwp_consumer/internal/inputs/ecmwf/test_mars.py
@@ -34,7 +34,7 @@ class TestECMWFMARSClient(unittest.TestCase):
         # Ensure the dimensions have the right sizes
         self.assertDictEqual(
             {"init_time": 1, "variable": 2, "step": 49, "latitude": 241, "longitude": 301},
-            dict(out.dims.items()),
+            dict(out.sizes.items()),
         )
         # Ensure the dimensions of the variables are in the correct order
         self.assertEqual(

--- a/src/nwp_consumer/internal/inputs/icon/test_client.py
+++ b/src/nwp_consumer/internal/inputs/icon/test_client.py
@@ -60,7 +60,7 @@ class TestParseIconFilename(unittest.TestCase):
         )
         self.assertIsNotNone(out)
         self.assertEqual(out.filename(), filename.removesuffix(".bz2"))
-        self.assertEqual(out.it(), dt.datetime(2020, 9, 1, 0, tzinfo=dt.timezone.utc))
+        self.assertEqual(out.it(), dt.datetime(2020, 9, 1, 0, tzinfo=dt.UTC))
 
     def test_parsesTimeInvariant(self) -> None:
         filename: str = "icon_global_icosahedral_time-invariant_2020090100_CLAT.grib2.bz2"

--- a/src/nwp_consumer/internal/inputs/metoffice/test_client.py
+++ b/src/nwp_consumer/internal/inputs/metoffice/test_client.py
@@ -37,7 +37,7 @@ class TestClient_ConvertRawFileToDataset(unittest.TestCase):
         # Ensure the dimensions have the right sizes
         self.assertDictEqual(
             {"init_time": 1, "variable": 1, "step": 13, "y": 639, "x": 455},
-            dict(out.dims.items()),
+            dict(out.sizes.items()),
         )
         # Ensure the dimensions of the variables are in the correct order
         self.assertEqual(("variable", "init_time", "step", "y", "x"), out["UKV"].dims)
@@ -52,7 +52,7 @@ class TestClient_ConvertRawFileToDataset(unittest.TestCase):
         # Ensure the dimensions have the right sizes
         self.assertDictEqual(
             {"init_time": 1, "variable": 1, "step": 13, "y": 639, "x": 455},
-            dict(out.dims.items()),
+            dict(out.sizes.items()),
         )
         # Ensure the dimensions of the variables are in the correct order
         self.assertEqual(out["UKV"].dims, ("variable", "init_time", "step", "y", "x"))
@@ -67,7 +67,7 @@ class TestClient_ConvertRawFileToDataset(unittest.TestCase):
         # Ensure the dimensions have the right sizes
         self.assertDictEqual(
             {"init_time": 1, "variable": 1, "step": 43, "y": 639, "x": 455},
-            dict(out.dims.items()),
+            dict(out.sizes.items()),
         )
         # Ensure the dimensions of the variables are in the correct order
         self.assertEqual(out["UKV"].dims, ("variable", "init_time", "step", "y", "x"))
@@ -82,7 +82,7 @@ class TestClient_ConvertRawFileToDataset(unittest.TestCase):
         # Ensure the dimensions have the right sizes
         self.assertDictEqual(
             {"init_time": 1, "variable": 1, "step": 10, "y": 639, "x": 455},
-            dict(out.dims.items()),
+            dict(out.sizes.items()),
         )
         # Ensure the dimensions of the variables are in the correct order
         self.assertEqual(("variable", "init_time", "step", "y", "x"), out["UKV"].dims)

--- a/src/nwp_consumer/internal/inputs/noaa/test_aws.py
+++ b/src/nwp_consumer/internal/inputs/noaa/test_aws.py
@@ -37,7 +37,7 @@ class TestParseIconFilename(unittest.TestCase):
 
     def test_parsesSingleLevel(self) -> None:
         filename: str = "gfs.t06z.pgrb2.0p25.f005"
-        it = dt.datetime(2020, 9, 1, 6, tzinfo=dt.timezone.utc)
+        it = dt.datetime(2020, 9, 1, 6, tzinfo=dt.UTC)
         out: NOAAFileInfo | None = _parseAWSFilename(
             name=filename,
             baseurl=f"{self.baseurl}/gfs.{it.strftime('%Y%m%d')}/{it.strftime('%H')}",
@@ -45,4 +45,4 @@ class TestParseIconFilename(unittest.TestCase):
         )
         self.assertIsNotNone(out)
         self.assertEqual(out.filename(), filename)
-        self.assertEqual(out.it(), dt.datetime(2020, 9, 1, 6, tzinfo=dt.timezone.utc))
+        self.assertEqual(out.it(), dt.datetime(2020, 9, 1, 6, tzinfo=dt.UTC))

--- a/src/test_integration/test_service_integration.py
+++ b/src/test_integration/test_service_integration.py
@@ -53,7 +53,7 @@ class TestNWPConsumerService_MetOffice(unittest.TestCase):
                 dict(ds.sizes.items()),
             )
             # Ensure the dimensions of the variables are in the correct order
-            self.assertEqual(("variable", "init_time", "step", "y", "x"), ds["UKV"].sizes.
+            self.assertEqual(("variable", "init_time", "step", "y", "x"), ds["UKV"].dims)
             # Ensure the init time is correct
             self.assertEqual(
                 np.datetime64(initTime.strftime("%Y-%m-%dT00:00")),

--- a/src/test_integration/test_service_integration.py
+++ b/src/test_integration/test_service_integration.py
@@ -50,10 +50,10 @@ class TestNWPConsumerService_MetOffice(unittest.TestCase):
             # Ensure the dimensions have the right sizes
             self.assertDictEqual(
                 {"variable": numVars, "init_time": 1, "step": 5, "y": 639, "x": 455},
-                dict(ds.dims.items()),
+                dict(ds.sizes.items()),
             )
             # Ensure the dimensions of the variables are in the correct order
-            self.assertEqual(("variable", "init_time", "step", "y", "x"), ds["UKV"].dims)
+            self.assertEqual(("variable", "init_time", "step", "y", "x"), ds["UKV"].sizes.
             # Ensure the init time is correct
             self.assertEqual(
                 np.datetime64(initTime.strftime("%Y-%m-%dT00:00")),
@@ -93,7 +93,7 @@ class TestNWPConsumerService_CEDA(unittest.TestCase):
             # Ensure the dimensions have the right sizes
             self.assertEqual(
                 {"variable": 12, "init_time": 1, "step": 37, "y": 704, "x": 548},
-                dict(ds.dims.items()),
+                dict(ds.sizes.items()),
             )
             # Ensure the init time is correct
             self.assertEqual(
@@ -143,7 +143,7 @@ class TestNWPConverterService_ECMWFMARS(unittest.TestCase):
                     "latitude": 241,
                     "longitude": 301,
                 },
-                dict(ds.dims.items()),
+                dict(ds.sizes.items()),
             )
             # Ensure the init time is correct
             self.assertEqual(
@@ -189,7 +189,7 @@ class TestNWPConsumerService_ICON(unittest.TestCase):
             # * Should be 4 steps due to the "3" hours
             self.assertEqual(
                 {"variable": 2, "init_time": 1, "step": 4, "latitude": 657, "longitude": 1377},
-                dict(ds.dims.items()),
+                dict(ds.sizes.items()),
             )
             # Ensure the init time is correct
             self.assertEqual(


### PR DESCRIPTION
Can use the Env var `DASK_SCHEDULER_ADDRESS` to specify an address to pass to a `dask.distributed` client.