### PR TITLE
test(ecmwf s3): Temperature variable renaming

### DIFF
--- a/src/nwp_consumer/internal/inputs/ecmwf/mars.py
+++ b/src/nwp_consumer/internal/inputs/ecmwf/mars.py
@@ -21,6 +21,7 @@ log = structlog.getLogger()
 
 PARAMETER_RENAME_MAP: dict[str, str] = {
     "tas": internal.OCFShortName.TemperatureAGL.value,
+    "t2m": internal.OCFShortName.TemperatureAGL.value,
     "uas": internal.OCFShortName.WindUComponentAGL.value,
     "vas": internal.OCFShortName.WindVComponentAGL.value,
     "dsrp": internal.OCFShortName.DirectSolarRadiation.value,

--- a/src/nwp_consumer/internal/inputs/ecmwf/s3.py
+++ b/src/nwp_consumer/internal/inputs/ecmwf/s3.py
@@ -22,6 +22,7 @@ PARAMETER_RENAME_MAP: dict[str, str] = {
     "uvb": internal.OCFShortName.DownwardUVRadiationAtSurface.value,
     "sd": internal.OCFShortName.SnowDepthWaterEquivalent.value,
     "tcc": internal.OCFShortName.TotalCloudCover.value,
+    "clt": internal.OCFShortName.TotalCloudCover.value,
     "u10": internal.OCFShortName.WindUComponentAGL.value,
     "v10": internal.OCFShortName.WindVComponentAGL.value,
     "t2m": internal.OCFShortName.TemperatureAGL.value,

--- a/src/nwp_consumer/internal/inputs/ecmwf/test_s3.py
+++ b/src/nwp_consumer/internal/inputs/ecmwf/test_s3.py
@@ -115,6 +115,8 @@ class TestS3Client(unittest.TestCase):
         )
         self.assertEqual(len(out.coords["variable"].to_numpy()), 18)
         self.assertEqual(out.coords["latitude"].to_numpy().max(), 60)
+        self.assertIn("t", list(out.coords["variable"].to_numpy()))
+        self.assertNotIn("t2m", list(out.coords["variable"].to_numpy()))
 
         # Check that setting the area maps only the relevant data
         indiaClient = S3Client(


### PR DESCRIPTION
Adds in to the test case a check that the rename map correctly results in the temperature variable being encoded in the zarr with "t".