### PR TITLE
fix(s3): Guard against ls errors

### DIFF
--- a/src/nwp_consumer/internal/inputs/ecmwf/s3.py
+++ b/src/nwp_consumer/internal/inputs/ecmwf/s3.py
@@ -123,6 +123,11 @@ class S3Client(internal.FetcherInterface):
         ds: xr.Dataset = xr.merge(area_dss, combine_attrs="drop_conflicts")
         del area_dss, all_dss
 
+        ds.drop_vars(
+            names=[v for v in ds.variables if v not in COORDINATE_ALLOW_LIST],
+            errors="ignore",
+        )
+
         # Map the data to the internal dataset representation
         # * Transpose the Dataset so that the dimensions are correctly ordered
         # * Rechunk the data to a more optimal size

--- a/src/nwp_consumer/internal/outputs/s3/client.py
+++ b/src/nwp_consumer/internal/outputs/s3/client.py
@@ -130,6 +130,14 @@ class Client(internal.StorageInterface):
     def copyITFolderToCache(self, *, prefix: pathlib.Path, it: dt.datetime) -> list[pathlib.Path]:
         """Overrides the corresponding method in the parent class."""
         initTimeDirPath = self.__bucket / prefix / it.strftime(internal.IT_FOLDER_STRUCTURE_RAW)
+
+        if not self.__fs.exists(initTimeDirPath.as_posix()) or not self.__fs.isdir(initTimeDirPath.as_posix()):
+            log.warn(
+                event="init time folder does not exist in store",
+                path=it.strftime(internal.IT_FOLDER_STRUCTURE_RAW),
+            )
+            return []
+
         paths = [
             pathlib.Path(p).relative_to(self.__bucket)
             for p in self.__fs.ls(initTimeDirPath.as_posix())

--- a/src/nwp_consumer/internal/service/consumer.py
+++ b/src/nwp_consumer/internal/service/consumer.py
@@ -122,7 +122,7 @@ class NWPConsumerService:
         bag: dask.bag.Bag = dask.bag.from_sequence(cachedPaths)
         cachedZarrs = (
             bag.map(lambda tfp: self.fetcher.mapCachedRaw(p=tfp))
-            .fold(lambda ds1, ds2: xr.merge([ds1, ds2], combine_attrs="drop_conflicts"))
+            .fold(lambda ds1, ds2: _mergeDatasets([ds1, ds2]))
             .compute()
         )
         datasets = dask.bag.from_sequence([cachedZarrs])


### PR DESCRIPTION
Fixes for bugs brought up by the implementation of the meteomatics live service. See #142 