### PR TITLE
Speed up on, saving to cloud

### DIFF
--- a/src/nwp_consumer/internal/entities/coordinates.py
+++ b/src/nwp_consumer/internal/entities/coordinates.py
@@ -90,9 +90,7 @@ class NWPDimensionCoordinateMap:
     Will be truncated to 4 decimal places, and ordered as 90 -> -90.
     """
     longitude: list[float] | None = None
-    """The longitude coordinates of the forecast grid in degrees. """
-    large_chunk_divider_size: int = 8
-    """ For large dimensions, the amount of steps in each chunk
+    """The longitude coordinates of the forecast grid in degrees. 
 
     Will be truncated to 4 decimal places, and ordered as -180 -> 180.
     """
@@ -119,15 +117,7 @@ class NWPDimensionCoordinateMap:
         index value list.
         """
         return [f.name for f in dataclasses.fields(self) if
-                getattr(self, f.name) is not None and f.name != "large_chunk_divider_size"]
-
-    def set_large_chunk_divider_size(self, large_chunk_divider_size: int) \
-            -> "NWPDimensionCoordinateMap":
-        """Set the large chunk divider size for the map.
-
-        This is the number of steps in each chunk for large dimensions.
-        """
-        return dataclasses.replace(self, large_chunk_divider_size=large_chunk_divider_size)
+                getattr(self, f.name) is not None]
 
     @property
     def shapemap(self) -> dict[str, int]:
@@ -420,8 +410,7 @@ class NWPDimensionCoordinateMap:
             "init_time": 1,
             "step": 1,
         } | {
-            dim: len(getattr(self, dim)) // self.large_chunk_divider_size
-            if len(getattr(self, dim)) > self.large_chunk_divider_size else 1
+            dim: len(getattr(self, dim)) // 8 if len(getattr(self, dim)) > 8 else 1
             for dim in self.dims
             if dim not in ["init_time", "step"]
         }

--- a/src/nwp_consumer/internal/entities/coordinates.py
+++ b/src/nwp_consumer/internal/entities/coordinates.py
@@ -92,8 +92,8 @@ class NWPDimensionCoordinateMap:
     longitude: list[float] | None = None
     """The longitude coordinates of the forecast grid in degrees. """
     maximum_number_of_chunks_in_one_dim: int = 8
-    """ The maximum number of chunks in one dimension. 
-    When saving to S3 we might want this to be small, to reduce the number of files saved. 
+    """ The maximum number of chunks in one dimension.
+    When saving to S3 we might want this to be small, to reduce the number of files saved.
 
     Will be truncated to 4 decimal places, and ordered as -180 -> 180.
     """
@@ -120,7 +120,8 @@ class NWPDimensionCoordinateMap:
         index value list.
         """
         return [f.name for f in dataclasses.fields(self) if
-                getattr(self, f.name) is not None and f.name != "maximum_number_of_chunks_in_one_dim"]
+                getattr(self, f.name) is not None
+                and f.name != "maximum_number_of_chunks_in_one_dim"]
 
     @property
     def shapemap(self) -> dict[str, int]:

--- a/src/nwp_consumer/internal/entities/coordinates.py
+++ b/src/nwp_consumer/internal/entities/coordinates.py
@@ -90,7 +90,7 @@ class NWPDimensionCoordinateMap:
     Will be truncated to 4 decimal places, and ordered as 90 -> -90.
     """
     longitude: list[float] | None = None
-    """The longitude coordinates of the forecast grid in degrees. 
+    """The longitude coordinates of the forecast grid in degrees.
 
     Will be truncated to 4 decimal places, and ordered as -180 -> 180.
     """

--- a/src/nwp_consumer/internal/entities/coordinates.py
+++ b/src/nwp_consumer/internal/entities/coordinates.py
@@ -92,8 +92,7 @@ class NWPDimensionCoordinateMap:
     longitude: list[float] | None = None
     """The longitude coordinates of the forecast grid in degrees. """
     large_chunk_divider_size: int | None = 8
-    """ For large dimensions, the amount of steps in each chunk/ 
-    
+    """ For large dimensions, the amount of steps in each chunk
 
     Will be truncated to 4 decimal places, and ordered as -180 -> 180.
     """
@@ -122,7 +121,8 @@ class NWPDimensionCoordinateMap:
         return [f.name for f in dataclasses.fields(self) if
                 getattr(self, f.name) is not None and f.name != "large_chunk_divider_size"]
 
-    def set_large_chunk_divider_size(self, large_chunk_divider_size: int) -> "NWPDimensionCoordinateMap":
+    def set_large_chunk_divider_size(self, large_chunk_divider_size: int) \
+            -> "NWPDimensionCoordinateMap":
         """Set the large chunk divider size for the map.
 
         This is the number of steps in each chunk for large dimensions.

--- a/src/nwp_consumer/internal/entities/coordinates.py
+++ b/src/nwp_consumer/internal/entities/coordinates.py
@@ -91,7 +91,7 @@ class NWPDimensionCoordinateMap:
     """
     longitude: list[float] | None = None
     """The longitude coordinates of the forecast grid in degrees. """
-    large_chunk_divider_size: int | None = 8
+    large_chunk_divider_size: int = 8
     """ For large dimensions, the amount of steps in each chunk
 
     Will be truncated to 4 decimal places, and ordered as -180 -> 180.

--- a/src/nwp_consumer/internal/entities/coordinates.py
+++ b/src/nwp_consumer/internal/entities/coordinates.py
@@ -38,6 +38,7 @@ a key part of parallel writing.
 import dataclasses
 import datetime as dt
 import json
+import logging
 from importlib.metadata import PackageNotFoundError, version
 
 import dask.array
@@ -54,12 +55,14 @@ try:
 except PackageNotFoundError:
     __version__ = "v?"
 
+log = logging.getLogger("nwp-consumer")
+
 
 @dataclasses.dataclass(slots=True)
 class NWPDimensionCoordinateMap:
     """Container for dimensions names and their coordinate index values.
 
-    Each field in the container is a dimension label, and the corresponding
+    Each public field in the container is a dimension label, and the corresponding
     value is a list of the coordinate values for each index along the dimension.
 
     All NWP data has an associated init time, step, and variable,
@@ -91,12 +94,6 @@ class NWPDimensionCoordinateMap:
     """
     longitude: list[float] | None = None
     """The longitude coordinates of the forecast grid in degrees. """
-    maximum_number_of_chunks_in_one_dim: int = 8
-    """ The maximum number of chunks in one dimension.
-    When saving to S3 we might want this to be small, to reduce the number of files saved.
-
-    Will be truncated to 4 decimal places, and ordered as -180 -> 180.
-    """
 
     def __post_init__(self) -> None:
         """Rigidly set input value ordering and precision."""
@@ -119,9 +116,7 @@ class NWPDimensionCoordinateMap:
         Ignores any dimensions that do not have a corresponding coordinate
         index value list.
         """
-        return [f.name for f in dataclasses.fields(self) if
-                getattr(self, f.name) is not None
-                and f.name != "maximum_number_of_chunks_in_one_dim"]
+        return [f.name for f in dataclasses.fields(self) if getattr(self, f.name) is not None]
 
     @property
     def shapemap(self) -> dict[str, int]:
@@ -384,6 +379,8 @@ class NWPDimensionCoordinateMap:
                 # TODO: of which might loop around the edges of the grid. In this case, it would
                 # TODO: be useful to determine if the run is non-contiguous only in that it wraps
                 # TODO: around that boundary, and in that case, split it and write it in two goes.
+                # TODO: 2025-01-06: I think this is a resolved problem now that fetch_init_data
+                # can return a list of DataArrays.
                 return Failure(
                     ValueError(
                         f"Coordinate values for dimension '{inner_dim_label}' do not correspond "
@@ -398,7 +395,7 @@ class NWPDimensionCoordinateMap:
 
         return Success(slices)
 
-    def default_chunking(self) -> dict[str, int]:
+    def chunking(self, chunk_count_overrides: dict[str, int]) -> dict[str, int]:
         """The expected chunk sizes for each dimension.
 
         A dictionary mapping of dimension labels to the size of a chunk along that
@@ -406,39 +403,50 @@ class NWPDimensionCoordinateMap:
         that wants to cover the entire dimension should have a size equal to the
         dimension length.
 
-        It defaults to a single chunk per init time and step, and 8 chunks
-        for each entire other dimension. These are purposefully small, to ensure
-        that when perfomring parallel writes, chunk boundaries are not crossed.
+        It defaults to a single chunk per init time, step, and variable coordinate,
+        and 2 chunks for each entire other dimension, unless overridden by the
+        `chunk_count_overrides` argument.
+
+        The defaults are purposefully small, to ensure that when performing parallel
+        writes, chunk boundaries are not crossed.
+
+        Args:
+            chunk_count_overrides: A dictionary mapping dimension labels to the
+                number of chunks to split the dimension into.
         """
         out_dict: dict[str, int] = {
             "init_time": 1,
             "step": 1,
+            "variable": 1,
         } | {
-            dim: len(getattr(self, dim)) // self.maximum_number_of_chunks_in_one_dim
-            if len(getattr(self, dim)) > self.maximum_number_of_chunks_in_one_dim else 1
+            dim: len(getattr(self, dim)) // chunk_count_overrides.get(dim, 2)
+            if len(getattr(self, dim)) > 8 else 1
             for dim in self.dims
-            if dim not in ["init_time", "step"]
+            if dim not in ["init_time", "step", "variable"]
         }
 
         return out_dict
 
 
-    def as_zeroed_dataarray(self, name: str) -> xr.DataArray:
+    def as_zeroed_dataarray(self, name: str, chunks: dict[str, int]) -> xr.DataArray:
         """Express the coordinates as an xarray DataArray.
 
-        Data is populated with zeros and a default chunking scheme is applied.
+        The underlying dask array is a zeroed array with the shape of the dataset,
+        that is chunked according to the given chunking scheme.
 
         Args:
             name: The name of the DataArray.
+            chunks: A mapping of dimension names to the size of the chunks
+                along the dimensions.
 
         See Also:
-        - https://docs.xarray.dev/en/stable/user-guide/io.html#distributed-writes
+            - https://docs.xarray.dev/en/stable/user-guide/io.html#distributed-writes
         """
         # Create a dask array of zeros with the shape of the dataset
         # * The values of this are ignored, only the shape and chunks are used
         dummy_values = dask.array.zeros(  # type: ignore
             shape=list(self.shapemap.values()),
-            chunks=tuple([self.default_chunking()[k] for k in self.shapemap]),
+            chunks=tuple([chunks[k] for k in self.shapemap]),
         )
         attrs: dict[str, str] = {
             "produced_by": "".join((

--- a/src/nwp_consumer/internal/entities/coordinates.py
+++ b/src/nwp_consumer/internal/entities/coordinates.py
@@ -410,7 +410,7 @@ class NWPDimensionCoordinateMap:
             "init_time": 1,
             "step": 1,
         } | {
-            dim: len(getattr(self, dim)) // 8 if len(getattr(self, dim)) > 8 else 1
+            dim: len(getattr(self, dim)) // 2 if len(getattr(self, dim)) > 2 else 1
             for dim in self.dims
             if dim not in ["init_time", "step"]
         }

--- a/src/nwp_consumer/internal/entities/modelmetadata.py
+++ b/src/nwp_consumer/internal/entities/modelmetadata.py
@@ -94,7 +94,7 @@ class ModelMetadata:
                 return self
 
     def set_large_chunk_divider_size(self, large_chunk_divider_size: int) -> "ModelMetadata":
-        """ Set the large chunk divider. """
+        """Set the large chunk divider."""
         self.expected_coordinates.large_chunk_divider_size = large_chunk_divider_size
         return self
 

--- a/src/nwp_consumer/internal/entities/modelmetadata.py
+++ b/src/nwp_consumer/internal/entities/modelmetadata.py
@@ -55,6 +55,15 @@ class ModelMetadata:
     Which prints grid data from the grib file.
     """
 
+    chunk_count_overrides: dict[str, int] = dataclasses.field(default_factory=dict)
+    """Mapping of dimension names to the desired number of chunks in that dimension.
+
+    Overrides the default chunking strategy.
+
+    See Also:
+        - `entities.coordinates.NWPDimensionCoordinateMap.chunking`
+    """
+
     def __str__(self) -> str:
         """Return a pretty-printed string representation of the metadata."""
         pretty: str = "".join((
@@ -93,13 +102,14 @@ class ModelMetadata:
                 log.warning(f"Unknown region '{region}', not cropping expected coordinates.")
                 return self
 
-    def set_maximum_number_of_chunks_in_one_dim(self, maximum_number_of_chunks_in_one_dim: int) \
-            -> "ModelMetadata":
-        """Set the maximum number of chunks in one dimension."""
-        self.expected_coordinates.maximum_number_of_chunks_in_one_dim \
-            = maximum_number_of_chunks_in_one_dim
-        return self
-
+    def with_chunk_count_overrides(self, overrides: dict[str, int]) -> "ModelMetadata":
+        """Returns metadata for the given model with the given chunk count overrides."""
+        if not set(overrides.keys()).issubset(self.expected_coordinates.dims):
+            log.warning(
+                "Chunk count overrides contain keys not in the expected coordinates. "
+                "These will not modify the chunking strategy.",
+            )
+        return dataclasses.replace(self, chunk_count_overrides=overrides)
 
 class Models:
     """Namespace containing known models."""

--- a/src/nwp_consumer/internal/entities/modelmetadata.py
+++ b/src/nwp_consumer/internal/entities/modelmetadata.py
@@ -93,6 +93,12 @@ class ModelMetadata:
                 log.warning(f"Unknown region '{region}', not cropping expected coordinates.")
                 return self
 
+    def set_maximum_number_of_chunks_in_one_dim(self, maximum_number_of_chunks_in_one_dim:int):
+        """Set the maximum number of chunks in one dimension."""
+        self.expected_coordinates.maximum_number_of_chunks_in_one_dim \
+            = maximum_number_of_chunks_in_one_dim
+        return self
+
 
 class Models:
     """Namespace containing known models."""

--- a/src/nwp_consumer/internal/entities/modelmetadata.py
+++ b/src/nwp_consumer/internal/entities/modelmetadata.py
@@ -93,7 +93,7 @@ class ModelMetadata:
                 log.warning(f"Unknown region '{region}', not cropping expected coordinates.")
                 return self
 
-    def set_large_chunk_divider_size(self, large_chunk_divider_size: int) -> "ModelMetadata"
+    def set_large_chunk_divider_size(self, large_chunk_divider_size: int) -> "ModelMetadata":
         """ Set the large chunk divider. """
         self.expected_coordinates.large_chunk_divider_size = large_chunk_divider_size
         return self

--- a/src/nwp_consumer/internal/entities/modelmetadata.py
+++ b/src/nwp_consumer/internal/entities/modelmetadata.py
@@ -93,6 +93,11 @@ class ModelMetadata:
                 log.warning(f"Unknown region '{region}', not cropping expected coordinates.")
                 return self
 
+    def set_large_chunk_divider_size(self, large_chunk_divider_size):
+        """ Set the large chunk divider"""
+        self.expected_coordinates.large_chunk_divider_size = large_chunk_divider_size
+        return self
+
 
 class Models:
     """Namespace containing known models."""

--- a/src/nwp_consumer/internal/entities/modelmetadata.py
+++ b/src/nwp_consumer/internal/entities/modelmetadata.py
@@ -93,7 +93,8 @@ class ModelMetadata:
                 log.warning(f"Unknown region '{region}', not cropping expected coordinates.")
                 return self
 
-    def set_maximum_number_of_chunks_in_one_dim(self, maximum_number_of_chunks_in_one_dim:int):
+    def set_maximum_number_of_chunks_in_one_dim(self, maximum_number_of_chunks_in_one_dim: int) \
+            -> "ModelMetadata":
         """Set the maximum number of chunks in one dimension."""
         self.expected_coordinates.maximum_number_of_chunks_in_one_dim \
             = maximum_number_of_chunks_in_one_dim

--- a/src/nwp_consumer/internal/entities/modelmetadata.py
+++ b/src/nwp_consumer/internal/entities/modelmetadata.py
@@ -93,11 +93,6 @@ class ModelMetadata:
                 log.warning(f"Unknown region '{region}', not cropping expected coordinates.")
                 return self
 
-    def set_large_chunk_divider_size(self, large_chunk_divider_size: int) -> "ModelMetadata":
-        """Set the large chunk divider."""
-        self.expected_coordinates.large_chunk_divider_size = large_chunk_divider_size
-        return self
-
 
 class Models:
     """Namespace containing known models."""

--- a/src/nwp_consumer/internal/entities/modelmetadata.py
+++ b/src/nwp_consumer/internal/entities/modelmetadata.py
@@ -93,8 +93,8 @@ class ModelMetadata:
                 log.warning(f"Unknown region '{region}', not cropping expected coordinates.")
                 return self
 
-    def set_large_chunk_divider_size(self, large_chunk_divider_size):
-        """ Set the large chunk divider"""
+    def set_large_chunk_divider_size(self, large_chunk_divider_size: int) -> "ModelMetadata"
+        """ Set the large chunk divider. """
         self.expected_coordinates.large_chunk_divider_size = large_chunk_divider_size
         return self
 

--- a/src/nwp_consumer/internal/entities/tensorstore.py
+++ b/src/nwp_consumer/internal/entities/tensorstore.py
@@ -275,7 +275,8 @@ class TensorStore(abc.ABC):
 
         # Perform the regional write
         try:
-            da.to_zarr(store=self.path, region=region, consolidated=True)
+            # TODO not use safe_chunks=False in general
+            da.to_zarr(store=self.path, region=region, consolidated=True, safe_chunks=False)
         except Exception as e:
             return Failure(
                 OSError(

--- a/src/nwp_consumer/internal/entities/tensorstore.py
+++ b/src/nwp_consumer/internal/entities/tensorstore.py
@@ -274,6 +274,7 @@ class TensorStore(abc.ABC):
             region = region_result.unwrap()
 
         # Perform the regional write
+        log.debug(f"Writing to region {region} of store {self.name}")
         try:
             # TODO not use safe_chunks=False in general
             da.to_zarr(store=self.path, region=region, consolidated=True, safe_chunks=False)

--- a/src/nwp_consumer/internal/entities/tensorstore.py
+++ b/src/nwp_consumer/internal/entities/tensorstore.py
@@ -16,7 +16,7 @@ import logging
 import os
 import pathlib
 import shutil
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping
 from typing import Any
 
 import pandas as pd
@@ -77,6 +77,7 @@ class TensorStore(abc.ABC):
         model: str,
         repository: str,
         coords: NWPDimensionCoordinateMap,
+        chunks: dict[str, int],
     ) -> ResultE["TensorStore"]:
         """Initialize a store for a given init time.
 
@@ -110,6 +111,7 @@ class TensorStore(abc.ABC):
                    This is also used as the name of the tensor.
             repository: The name of the repository providing the tensor data.
             coords: The coordinates of the store.
+            chunks: The chunk sizes for the store.
 
         Returns:
             An indicator of a successful store write containing the number of bytes written.
@@ -152,7 +154,8 @@ class TensorStore(abc.ABC):
         # Write the coordinates to a skeleton Zarr store
         # * 'compute=False' enables only saving metadata
         # * 'mode="w-"' fails if it finds an existing store
-        da: xr.DataArray = coords.as_zeroed_dataarray(name=model)
+
+        da: xr.DataArray = coords.as_zeroed_dataarray(name=model, chunks=chunks)
         encoding = {
             model: {"write_empty_chunks": False},
             "init_time": {"units": "nanoseconds since 1970-01-01"},
@@ -257,12 +260,19 @@ class TensorStore(abc.ABC):
         If the region dict is empty or not provided, the region is determined
         via the 'determine_region' method.
 
+        This function should be thread safe, so a check is performed on the region
+        to ensure that it can be safely written to in parallel, i.e. that it covers
+        an integer number of chunks.
+
         Args:
             da: The data to write to the store.
             region: The region to write to.
 
         Returns:
             An indicator of a successful store write containing the number of bytes written.
+
+        See Also:
+            - https://docs.xarray.dev/en/stable/user-guide/io.html#distributed-writes
         """
         # Attempt to determine the region if missing
         if region is None or region == {}:
@@ -270,8 +280,31 @@ class TensorStore(abc.ABC):
                 self.coordinate_map.determine_region,
             )
             if isinstance(region_result, Failure):
-                return Failure(region_result.failure())
+                return region_result
             region = region_result.unwrap()
+
+        # For each dimensional slice defining the region, check the slice represents an
+        # integer number of chunks along that dimension.
+        # * This is to ensure that the data can safely be written in parallel.
+        # * The start and and of each slice should be divisible by the chunk size.
+        chunksizes: Mapping[Any, tuple[int, ...]] = xr.open_dataarray(
+            self.path, engine="zarr",
+        ).chunksizes
+        for dim, slc in region.items():
+            chunk_size = chunksizes.get(dim, (1,))[0]
+            # TODO: Determine if this should return a full failure object
+            if slc.start % chunk_size != 0 or slc.stop % chunk_size != 0:
+                log.warning(
+                    f"Determined region of raw data to be written for dimension '{dim}'"
+                    f"does not align with chunk boundaries of the store. "
+                    f"Dimension '{dim}' has a chunk size of {chunk_size}, "
+                    "but the data to be written for this dimension starts at chunk "
+                    f"{slc.start / chunk_size:.2f} (index {slc.start}) and ends at chunk "
+                    f"{slc.stop / chunk_size:.2f} (index {slc.stop}). "
+                    "As such, this region cannot be safely written in parallel. "
+                    "Ensure the chunking is granular enough to cover the raw data region.",
+                )
+
 
         # Perform the regional write
         try:

--- a/src/nwp_consumer/internal/entities/tensorstore.py
+++ b/src/nwp_consumer/internal/entities/tensorstore.py
@@ -274,10 +274,8 @@ class TensorStore(abc.ABC):
             region = region_result.unwrap()
 
         # Perform the regional write
-        log.debug(f"Writing to region {region} of store {self.name}")
         try:
-            # TODO not use safe_chunks=False in general
-            da.to_zarr(store=self.path, region=region, consolidated=True, safe_chunks=False)
+            da.to_zarr(store=self.path, region=region, consolidated=True)
         except Exception as e:
             return Failure(
                 OSError(

--- a/src/nwp_consumer/internal/entities/test_tensorstore.py
+++ b/src/nwp_consumer/internal/entities/test_tensorstore.py
@@ -89,6 +89,7 @@ class TestTensorStore(unittest.TestCase):
             model="test_da",
             repository="dummy_repository",
             coords=test_coords,
+            chunks=test_coords.chunking(chunk_count_overrides={}),
         )
         self.assertIsInstance(init_result, Success, msg=init_result)
         store = init_result.unwrap()

--- a/src/nwp_consumer/internal/repositories/raw_repositories/ceda_ftp.py
+++ b/src/nwp_consumer/internal/repositories/raw_repositories/ceda_ftp.py
@@ -121,7 +121,10 @@ class CEDAFTPRawRepository(ports.RawRepository):
             optional_env={},
             postprocess_options=entities.PostProcessOptions(),
             available_models={
-                "default": entities.Models.MO_UM_GLOBAL_17KM,
+                "default": entities.Models.MO_UM_GLOBAL_17KM.with_chunk_count_overrides({
+                    "latitude": 8,
+                    "longitude": 8,
+                }),
             },
         )
 

--- a/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
+++ b/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
@@ -285,9 +285,6 @@ class ECMWFRealTimeS3RawRepository(ports.RawRepository):
                     .sortby(variables="latitude", ascending=False)
                 )
 
-                # change lat and lon chunk size to 1
-                # da = da.chunk({"latitude": 1, "longitude": 1})
-
             except Exception as e:
                 return Failure(ValueError(
                     f"Error processing dataset {i} from '{path}' to DataArray: {e}",

--- a/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
+++ b/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
@@ -83,8 +83,10 @@ class ECMWFRealTimeS3RawRepository(ports.RawRepository):
             },
             postprocess_options=entities.PostProcessOptions(),
             available_models={
-                "default": entities.Models.ECMWF_HRES_IFS_0P1DEGREE.with_region("uk"),
-                "hres-ifs-uk": entities.Models.ECMWF_HRES_IFS_0P1DEGREE.with_region("uk"),
+                "default": entities.Models.ECMWF_HRES_IFS_0P1DEGREE.with_region("uk")
+                .set_large_chunk_divider_size(1),
+                "hres-ifs-uk": entities.Models.ECMWF_HRES_IFS_0P1DEGREE.with_region("uk")
+                .set_large_chunk_divider_size(1),
                 "hres-ifs-india": entities.Models.ECMWF_HRES_IFS_0P1DEGREE.with_region("india"),
             },
         )
@@ -138,7 +140,7 @@ class ECMWFRealTimeS3RawRepository(ports.RawRepository):
             f"Found {len(urls)} file(s) for init time '{it.strftime('%Y-%m-%d %H:%M')}' "
             f"in bucket path '{self.bucket}/ecmwf'.",
         )
-        for url in urls:
+        for url in urls[0:3]:
             yield delayed(self._download_and_convert)(url=url)
 
     @classmethod
@@ -284,7 +286,7 @@ class ECMWFRealTimeS3RawRepository(ports.RawRepository):
                 )
 
                 # change lat and lon chunk size to 1
-                da = da.chunk({"latitude": 17, "longitude": 18})
+                da = da.chunk({"latitude": 1, "longitude": 1})
 
             except Exception as e:
                 return Failure(ValueError(

--- a/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
+++ b/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
@@ -140,7 +140,7 @@ class ECMWFRealTimeS3RawRepository(ports.RawRepository):
             f"Found {len(urls)} file(s) for init time '{it.strftime('%Y-%m-%d %H:%M')}' "
             f"in bucket path '{self.bucket}/ecmwf'.",
         )
-        for url in urls[0:3]:
+        for url in urls:
             yield delayed(self._download_and_convert)(url=url)
 
     @classmethod

--- a/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
+++ b/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
@@ -138,7 +138,7 @@ class ECMWFRealTimeS3RawRepository(ports.RawRepository):
             f"Found {len(urls)} file(s) for init time '{it.strftime('%Y-%m-%d %H:%M')}' "
             f"in bucket path '{self.bucket}/ecmwf'.",
         )
-        for url in urls[0:3]:
+        for url in urls:
             yield delayed(self._download_and_convert)(url=url)
 
     @classmethod

--- a/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
+++ b/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
@@ -284,7 +284,7 @@ class ECMWFRealTimeS3RawRepository(ports.RawRepository):
                 )
 
                 # change lat and lon chunk size to 1
-                da = da.chunk({"latitude": 1, "longitude": 1})
+                da = da.chunk({"latitude": 17, "longitude": 18})
 
             except Exception as e:
                 return Failure(ValueError(

--- a/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
+++ b/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
@@ -204,6 +204,7 @@ class ECMWFRealTimeS3RawRepository(ports.RawRepository):
                     raise FileNotFoundError(f"File not found at '{url}'")
 
                 with local_path.open("wb") as lf, self._fs.open(url, "rb") as rf:
+                    log.info(f"Writing file from {url} to {local_path}")
                     for chunk in iter(lambda: rf.read(12 * 1024), b""):
                         lf.write(chunk)
                         lf.flush()

--- a/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
+++ b/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
@@ -83,10 +83,8 @@ class ECMWFRealTimeS3RawRepository(ports.RawRepository):
             },
             postprocess_options=entities.PostProcessOptions(),
             available_models={
-                "default": entities.Models.ECMWF_HRES_IFS_0P1DEGREE.with_region("uk")
-                .set_large_chunk_divider_size(1),
-                "hres-ifs-uk": entities.Models.ECMWF_HRES_IFS_0P1DEGREE.with_region("uk")
-                .set_large_chunk_divider_size(1),
+                "default": entities.Models.ECMWF_HRES_IFS_0P1DEGREE.with_region("uk"),
+                "hres-ifs-uk": entities.Models.ECMWF_HRES_IFS_0P1DEGREE.with_region("uk"),
                 "hres-ifs-india": entities.Models.ECMWF_HRES_IFS_0P1DEGREE.with_region("india"),
             },
         )

--- a/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
+++ b/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
@@ -282,6 +282,10 @@ class ECMWFRealTimeS3RawRepository(ports.RawRepository):
                     .sortby(variables=["step", "variable", "longitude"])
                     .sortby(variables="latitude", ascending=False)
                 )
+
+                # change lat and lon chunk size to 1
+                da = da.chunk({"latitude": 1, "longitude": 1})
+
             except Exception as e:
                 return Failure(ValueError(
                     f"Error processing dataset {i} from '{path}' to DataArray: {e}",

--- a/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
+++ b/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
@@ -83,8 +83,10 @@ class ECMWFRealTimeS3RawRepository(ports.RawRepository):
             },
             postprocess_options=entities.PostProcessOptions(),
             available_models={
-                "default": entities.Models.ECMWF_HRES_IFS_0P1DEGREE.with_region("uk"),
-                "hres-ifs-uk": entities.Models.ECMWF_HRES_IFS_0P1DEGREE.with_region("uk"),
+                "default": entities.Models.ECMWF_HRES_IFS_0P1DEGREE.with_region("uk")
+                .set_maximum_number_of_chunks_in_one_dim(2),
+                "hres-ifs-uk": entities.Models.ECMWF_HRES_IFS_0P1DEGREE.with_region("uk")
+                .set_maximum_number_of_chunks_in_one_dim(2),
                 "hres-ifs-india": entities.Models.ECMWF_HRES_IFS_0P1DEGREE.with_region("india"),
             },
         )
@@ -138,7 +140,7 @@ class ECMWFRealTimeS3RawRepository(ports.RawRepository):
             f"Found {len(urls)} file(s) for init time '{it.strftime('%Y-%m-%d %H:%M')}' "
             f"in bucket path '{self.bucket}/ecmwf'.",
         )
-        for url in urls:
+        for url in urls[0:3]:
             yield delayed(self._download_and_convert)(url=url)
 
     @classmethod

--- a/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
+++ b/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
@@ -284,7 +284,7 @@ class ECMWFRealTimeS3RawRepository(ports.RawRepository):
                 )
 
                 # change lat and lon chunk size to 1
-                da = da.chunk({"latitude": 1, "longitude": 1})
+                # da = da.chunk({"latitude": 1, "longitude": 1})
 
             except Exception as e:
                 return Failure(ValueError(

--- a/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
+++ b/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
@@ -194,6 +194,7 @@ class ECMWFRealTimeS3RawRepository(ports.RawRepository):
         ).with_suffix(".grib").expanduser()
 
         # Only download the file if not already present
+        log.info("Checking for local file: '%s'", local_path)
         if not local_path.exists() or local_path.stat().st_size == 0:
             local_path.parent.mkdir(parents=True, exist_ok=True)
             log.debug("Requesting file from S3 at: '%s'", url)

--- a/src/nwp_consumer/internal/services/consumer_service.py
+++ b/src/nwp_consumer/internal/services/consumer_service.py
@@ -107,16 +107,18 @@ class ConsumerService(ports.ConsumeUseCase):
         """
         # TODO: Change this based on threads instead of CPU count
         n_jobs: int = max(cpu_count() - 1, max_connections)
-        if os.getenv("CONCURRENCY", "True").capitalize() == "False":
-            n_jobs = 1
-        elif os.getenv("NUMBER_CONCURRENT_JOBS") is not None:
-            n_jobs = int(str(os.getenv("NUMBER_CONCURRENT_JOBS")))
+        prefer = "threads"
 
-        log.debug(f"Using {n_jobs} concurrent thread(s)")
+        concurrency = os.getenv("CONCURRENCY", "True").capitalize() == "False"
+        if concurrency:
+            n_jobs = 1
+            prefer = "processes"
+
+        log.debug(f"Using {n_jobs} concurrent {prefer}")
 
         return Parallel(  # type: ignore
             n_jobs=n_jobs,
-            prefer="processes", # TODO should not leave it as processes
+            prefer=prefer,
             verbose=0,
             return_as="generator_unordered",
         )(delayed_generator)

--- a/src/nwp_consumer/internal/services/consumer_service.py
+++ b/src/nwp_consumer/internal/services/consumer_service.py
@@ -117,7 +117,7 @@ class ConsumerService(ports.ConsumeUseCase):
         return Parallel(  # type: ignore
             n_jobs=n_jobs,
             prefer="threads",
-            verbose=0,
+            verbose=1,
             return_as="generator_unordered",
         )(delayed_generator)
 

--- a/src/nwp_consumer/internal/services/consumer_service.py
+++ b/src/nwp_consumer/internal/services/consumer_service.py
@@ -117,7 +117,7 @@ class ConsumerService(ports.ConsumeUseCase):
         return Parallel(  # type: ignore
             n_jobs=n_jobs,
             prefer="processes", # TODO should not leave it as processes
-            verbose=1,
+            verbose=0,
             return_as="generator_unordered",
         )(delayed_generator)
 

--- a/src/nwp_consumer/internal/services/consumer_service.py
+++ b/src/nwp_consumer/internal/services/consumer_service.py
@@ -110,7 +110,10 @@ class ConsumerService(ports.ConsumeUseCase):
         if os.getenv("CONCURRENCY", "True").capitalize() == "False":
             n_jobs = 1
         elif os.getenv("NUMBER_CONCURRENT_JOBS") is not None:
-            n_jobs = int(str(os.getenv("NUMBER_CONCURRENT_JOBS")))
+            number_of_current_jobs = os.getenv("NUMBER_CONCURRENT_JOBS")
+            assert number_of_current_jobs is not None
+            assert number_of_current_jobs.isnumeric()
+            n_jobs = int(number_of_current_jobs)
         log.debug(f"Using {n_jobs} concurrent thread(s)")
 
         return Parallel(  # type: ignore

--- a/src/nwp_consumer/internal/services/consumer_service.py
+++ b/src/nwp_consumer/internal/services/consumer_service.py
@@ -116,7 +116,7 @@ class ConsumerService(ports.ConsumeUseCase):
 
         return Parallel(  # type: ignore
             n_jobs=n_jobs,
-            prefer="threads",
+            prefer="processes", # TODO should not leave it as processes
             verbose=1,
             return_as="generator_unordered",
         )(delayed_generator)

--- a/src/nwp_consumer/internal/services/consumer_service.py
+++ b/src/nwp_consumer/internal/services/consumer_service.py
@@ -110,10 +110,8 @@ class ConsumerService(ports.ConsumeUseCase):
         if os.getenv("CONCURRENCY", "True").capitalize() == "False":
             n_jobs = 1
         elif os.getenv("NUMBER_CONCURRENT_JOBS") is not None:
-            number_of_current_jobs = os.getenv("NUMBER_CONCURRENT_JOBS")
-            assert number_of_current_jobs is not None
-            assert number_of_current_jobs.isnumeric()
-            n_jobs = int(number_of_current_jobs)
+            n_jobs = int(str(os.getenv("NUMBER_CONCURRENT_JOBS")))
+
         log.debug(f"Using {n_jobs} concurrent thread(s)")
 
         return Parallel(  # type: ignore

--- a/src/nwp_consumer/internal/services/consumer_service.py
+++ b/src/nwp_consumer/internal/services/consumer_service.py
@@ -110,7 +110,7 @@ class ConsumerService(ports.ConsumeUseCase):
         if os.getenv("CONCURRENCY", "True").capitalize() == "False":
             n_jobs = 1
         elif os.getenv("NUMBER_CONCURRENT_JOBS") is not None:
-            n_jobs = int(os.getenv("NUMBER_CONCURRENT_JOBS"))
+            n_jobs = int(str(os.getenv("NUMBER_CONCURRENT_JOBS")))
         log.debug(f"Using {n_jobs} concurrent thread(s)")
 
         return Parallel(  # type: ignore

--- a/src/nwp_consumer/internal/services/consumer_service.py
+++ b/src/nwp_consumer/internal/services/consumer_service.py
@@ -109,6 +109,8 @@ class ConsumerService(ports.ConsumeUseCase):
         n_jobs: int = max(cpu_count() - 1, max_connections)
         if os.getenv("CONCURRENCY", "True").capitalize() == "False":
             n_jobs = 1
+        elif os.getenv("NUMBER_CONCURRENT_JOBS") is not None:
+            n_jobs = int(os.getenv("NUMBER_CONCURRENT_JOBS"))
         log.debug(f"Using {n_jobs} concurrent thread(s)")
 
         return Parallel(  # type: ignore

--- a/src/nwp_consumer/internal/services/consumer_service.py
+++ b/src/nwp_consumer/internal/services/consumer_service.py
@@ -106,13 +106,12 @@ class ConsumerService(ports.ConsumeUseCase):
             max_connections: The maximum number of connections to use.
         """
         # TODO: Change this based on threads instead of CPU count
+        # TODO: Enable choosing between threads and processes?
         n_jobs: int = max(cpu_count() - 1, max_connections)
         prefer = "threads"
 
-        concurrency = os.getenv("CONCURRENCY", "True").capitalize() == "False"
-        if concurrency:
+        if os.getenv("CONCURRENCY", "True").capitalize() == "False":
             n_jobs = 1
-            prefer = "processes"
 
         log.debug(f"Using {n_jobs} concurrent {prefer}")
 
@@ -155,6 +154,9 @@ class ConsumerService(ports.ConsumeUseCase):
             coords=dataclasses.replace(
                 model_metadata.expected_coordinates,
                 init_time=its,
+            ),
+            chunks=model_metadata.expected_coordinates.chunking(
+                chunk_count_overrides=model_metadata.chunk_count_overrides,
             ),
         )
 


### PR DESCRIPTION
# Pull Request

## Description

- Only uses processes, not threads in the cloud
- reduce chunks from 8 in lat, lon and variables to 2, this reduce the numbers of files by 64. Down from ~50,000 to ~700. This makes writing to s3 much quicker. Reduces the run time from 1 hour to 10 mins. 
- For archive, all the options default to what they were before

https://github.com/openclimatefix/ocf-infrastructure/issues/697

## How Has This Been Tested?

- [x] CI tests
- [x]  Ran locally
- [x] Tested on Development 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
