### PR TITLE
fix(coordinate): Log warning on unsafe regional writes

### DIFF
--- a/src/nwp_consumer/internal/entities/modelmetadata.py
+++ b/src/nwp_consumer/internal/entities/modelmetadata.py
@@ -93,13 +93,6 @@ class ModelMetadata:
                 log.warning(f"Unknown region '{region}', not cropping expected coordinates.")
                 return self
 
-    def set_maximum_number_of_chunks_in_one_dim(self, maximum_number_of_chunks_in_one_dim: int) \
-            -> "ModelMetadata":
-        """Set the maximum number of chunks in one dimension."""
-        self.expected_coordinates.maximum_number_of_chunks_in_one_dim \
-            = maximum_number_of_chunks_in_one_dim
-        return self
-
 
 class Models:
     """Namespace containing known models."""

--- a/src/nwp_consumer/internal/entities/modelmetadata.py
+++ b/src/nwp_consumer/internal/entities/modelmetadata.py
@@ -55,6 +55,15 @@ class ModelMetadata:
     Which prints grid data from the grib file.
     """
 
+    chunk_count_overrides: dict[str, int] = dataclasses.field(default_factory=dict)
+    """Mapping of dimension names to the desired number of chunks in that dimension.
+
+    Overrides the default chunking strategy.
+
+    See Also:
+        - `entities.coordinates.NWPDimensionCoordinateMap.chunking`
+    """
+
     def __str__(self) -> str:
         """Return a pretty-printed string representation of the metadata."""
         pretty: str = "".join((
@@ -93,6 +102,14 @@ class ModelMetadata:
                 log.warning(f"Unknown region '{region}', not cropping expected coordinates.")
                 return self
 
+    def with_chunk_count_overrides(self, overrides: dict[str, int]) -> "ModelMetadata":
+        """Returns metadata for the given model with the given chunk count overrides."""
+        if not set(overrides.keys()).issubset(self.expected_coordinates.dims):
+            log.warning(
+                "Chunk count overrides contain keys not in the expected coordinates. "
+                "These will not modify the chunking strategy.",
+            )
+        return dataclasses.replace(self, chunk_count_overrides=overrides)
 
 class Models:
     """Namespace containing known models."""

--- a/src/nwp_consumer/internal/entities/tensorstore.py
+++ b/src/nwp_consumer/internal/entities/tensorstore.py
@@ -291,7 +291,7 @@ class TensorStore(abc.ABC):
             self.path, engine="zarr",
         ).chunksizes
         for dim, slc in region.items():
-            chunk_size = chunksizes[dim][0]
+            chunk_size = chunksizes.get(dim, (1,))[0]
             # TODO: Determine if this should return a full failure object
             if slc.start % chunk_size != 0 or slc.stop % chunk_size != 0:
                 log.warning(

--- a/src/nwp_consumer/internal/entities/tensorstore.py
+++ b/src/nwp_consumer/internal/entities/tensorstore.py
@@ -16,7 +16,7 @@ import logging
 import os
 import pathlib
 import shutil
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping
 from typing import Any
 
 import pandas as pd
@@ -287,9 +287,11 @@ class TensorStore(abc.ABC):
         # integer number of chunks along that dimension.
         # * This is to ensure that the data can safely be written in parallel.
         # * The start and and of each slice should be divisible by the chunk size.
-        chunksizes: tuple[int] = xr.open_dataarray(self.path, engine="zarr").data.chunksize
+        chunksizes: Mapping[Any, tuple[int, ...]] = xr.open_dataarray(
+            self.path, engine="zarr",
+        ).chunksizes
         for dim, slc in region.items():
-            chunk_size = chunksizes[da.get_axis_num(dim)]
+            chunk_size = chunksizes[dim][0]
             # TODO: Determine if this should return a full failure object
             if slc.start % chunk_size != 0 or slc.stop % chunk_size != 0:
                 log.warning(

--- a/src/nwp_consumer/internal/entities/test_tensorstore.py
+++ b/src/nwp_consumer/internal/entities/test_tensorstore.py
@@ -89,6 +89,7 @@ class TestTensorStore(unittest.TestCase):
             model="test_da",
             repository="dummy_repository",
             coords=test_coords,
+            chunks=test_coords.chunking(chunk_count_overrides={}),
         )
         self.assertIsInstance(init_result, Success, msg=init_result)
         store = init_result.unwrap()

--- a/src/nwp_consumer/internal/repositories/raw_repositories/ceda_ftp.py
+++ b/src/nwp_consumer/internal/repositories/raw_repositories/ceda_ftp.py
@@ -121,7 +121,10 @@ class CEDAFTPRawRepository(ports.RawRepository):
             optional_env={},
             postprocess_options=entities.PostProcessOptions(),
             available_models={
-                "default": entities.Models.MO_UM_GLOBAL_17KM,
+                "default": entities.Models.MO_UM_GLOBAL_17KM.with_chunk_count_overrides({
+                    "latitude": 8,
+                    "longitude": 8,
+                }),
             },
         )
 

--- a/src/nwp_consumer/internal/services/consumer_service.py
+++ b/src/nwp_consumer/internal/services/consumer_service.py
@@ -110,7 +110,7 @@ class ConsumerService(ports.ConsumeUseCase):
         n_jobs: int = max(cpu_count() - 1, max_connections)
         prefer = "threads"
 
-        if os.getenv("CONCURRENCY", "True").capitalize() == "False"
+        if os.getenv("CONCURRENCY", "True").capitalize() == "False":
             n_jobs = 1
 
         log.debug(f"Using {n_jobs} concurrent {prefer}")
@@ -154,6 +154,9 @@ class ConsumerService(ports.ConsumeUseCase):
             coords=dataclasses.replace(
                 model_metadata.expected_coordinates,
                 init_time=its,
+            ),
+            chunks=model_metadata.expected_coordinates.chunking(
+                chunk_count_overrides=model_metadata.chunk_count_overrides,
             ),
         )
 

--- a/src/nwp_consumer/internal/services/consumer_service.py
+++ b/src/nwp_consumer/internal/services/consumer_service.py
@@ -106,13 +106,12 @@ class ConsumerService(ports.ConsumeUseCase):
             max_connections: The maximum number of connections to use.
         """
         # TODO: Change this based on threads instead of CPU count
+        # TODO: Enable choosing between threads and processes?
         n_jobs: int = max(cpu_count() - 1, max_connections)
         prefer = "threads"
 
-        concurrency = os.getenv("CONCURRENCY", "True").capitalize() == "False"
-        if concurrency:
+        if os.getenv("CONCURRENCY", "True").capitalize() == "False"
             n_jobs = 1
-            prefer = "processes"
 
         log.debug(f"Using {n_jobs} concurrent {prefer}")
 


### PR DESCRIPTION
In response to my own comments on PR #214 I've made some changes.

Since chunking is an IO decision to do with the written data and not the read in data, the chunking is relevant only to the write_to_region and create_suitable_store functions. In order to enable for different chunking from the default for the repositories that require it due to the natire of their files, overrides can be set in the repository metadata.