### PR TITLE
reduce delay to 5 hours

### DIFF
--- a/src/nwp_consumer/internal/repositories/raw_repositories/noaa_s3.py
+++ b/src/nwp_consumer/internal/repositories/raw_repositories/noaa_s3.py
@@ -44,7 +44,7 @@ class NOAAS3RawRepository(ports.RawRepository):
             is_archive=False,
             is_order_based=False,
             running_hours=[0, 6, 12, 18],
-            delay_minutes=(60 * 24 * 7),  # 1 week
+            delay_minutes=(60 * 5),  # 5 hours
             max_connections=100,
             required_env=[],
             optional_env={},


### PR DESCRIPTION
# Pull Request

## Description

Reduce delay to 5 hours.
By checking a few date stamps, the files are ready >3 and <5 hours. So setting the delay at 5 hours, means we should get all the files

<img width="569" alt="Screenshot 2025-01-10 at 16 13 57" src="https://github.com/user-attachments/assets/1ccd3e26-ecc1-45d1-8d89-f9663e32366d" />

helps with https://github.com/openclimatefix/ocf-infrastructure/issues/697


## How Has This Been Tested?

- [x] CI tests
- [x] ran locally

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
