### PR TITLE
fix(gfs): Remove unwanted clashing variable

### DIFF
--- a/src/nwp_consumer/internal/repositories/raw_repositories/noaa_s3.py
+++ b/src/nwp_consumer/internal/repositories/raw_repositories/noaa_s3.py
@@ -248,6 +248,7 @@ class NOAAS3RawRepository(ports.RawRepository):
             ))
 
         try:
+            ds = ds.drop_vars("sdwe", errors="ignore") # Datasets contain both SDWE and SD
             ds = entities.Parameter.rename_else_drop_ds_vars(
                 ds=ds,
                 allowed_parameters=NOAAS3RawRepository.model().expected_coordinates.variable,


### PR DESCRIPTION
GFS datasets contain both `sdwe` and `sde` - we only want `sde`, measured in meters.