### PR TITLE
add north60 as an option

### DIFF
--- a/src/nwp_consumer/internal/entities/modelmetadata.py
+++ b/src/nwp_consumer/internal/entities/modelmetadata.py
@@ -102,6 +102,13 @@ class ModelMetadata:
                 ).map(lambda coords: dataclasses.replace(
                     self, name=f"{self.name}_uk", expected_coordinates=coords,
                 )).unwrap()
+            case "uk-north60":
+                # same as uk. but north is 60, not 62
+                return self.expected_coordinates.crop(
+                    north=60, west=-12, south=48, east=3,
+                ).map(lambda coords: dataclasses.replace(
+                    self, name=f"{self.name}_uk", expected_coordinates=coords,
+                )).unwrap()
             case "india":
                 return self.expected_coordinates.crop(
                     north=35, west=67, south=6, east=97,

--- a/src/nwp_consumer/internal/entities/tensorstore.py
+++ b/src/nwp_consumer/internal/entities/tensorstore.py
@@ -325,7 +325,7 @@ class TensorStore(abc.ABC):
     @staticmethod
     def _has_nans(store_da: xr.DataArray) -> ResultE[bool]:
         """Check the store for NaN values."""
-        nans_in_image_threshold: float = 0.2
+        nans_in_image_threshold: float = 0.05
         images_failing_nan_check_threshold: float = 0.02
         def _calc_null_percentage(data: np.typing.NDArray[np.float32]) -> float:
             nulls = np.isnan(data)

--- a/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
+++ b/src/nwp_consumer/internal/repositories/raw_repositories/ecmwf_realtime.py
@@ -82,8 +82,8 @@ class ECMWFRealTimeS3RawRepository(ports.RawRepository):
             },
             postprocess_options=entities.PostProcessOptions(),
             available_models={
-                "default": entities.Models.ECMWF_HRES_IFS_0P1DEGREE.with_region("uk"),
-                "hres-ifs-uk": entities.Models.ECMWF_HRES_IFS_0P1DEGREE.with_region("uk"),
+                "default": entities.Models.ECMWF_HRES_IFS_0P1DEGREE.with_region("uk-north60"),
+                "hres-ifs-uk": entities.Models.ECMWF_HRES_IFS_0P1DEGREE.with_region("uk-north60"),
                 "hres-ifs-india": entities.Models.ECMWF_HRES_IFS_0P1DEGREE.with_region("india")\
                     .with_chunk_count_overrides({"variable": 1}),
             },


### PR DESCRIPTION
# Pull Request

## Description

ECMWF live only goes to 60 north, so restrct it to that

This means ECMWF doesnt repeat itself

Also reduce nan margins

## How Has This Been Tested?

- [x] CI tets
- [x] run on dev, and ECMWF doesnt repeat itself now

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
